### PR TITLE
good_XYZ stub replaced with good in key goodfile

### DIFF
--- a/microservices/cmslitemetadata_to_redshift/cmslitemetadata_to_redshift.py
+++ b/microservices/cmslitemetadata_to_redshift/cmslitemetadata_to_redshift.py
@@ -124,7 +124,7 @@ for object_summary in my_bucket.objects.filter(Prefix=source + "/" + directory +
         # Check to see if the file has been processed already
         batchfile = destination + "/batch/" + object_summary.key
         # XX we have temporarily overriden the check for successfully processed files
-        goodfile = destination + "/good_XYZ/" + object_summary.key
+        goodfile = destination + "/good/" + object_summary.key
         badfile = destination + "/bad/" + object_summary.key
         try:
             client.head_object(Bucket=bucket, Key=goodfile)


### PR DESCRIPTION
`good_XYZ` was used as a stub to allow repeated testing on a sample file. the `goodfile` key should actually point to the `good` prefix to operate correctly.