### PR TITLE
update to match json and py on microservice ec2

### DIFF
--- a/microservices/cmslitemetadata_to_redshift/cmslite_gdx.json
+++ b/microservices/cmslitemetadata_to_redshift/cmslite_gdx.json
@@ -3,7 +3,7 @@
   "source": "client",
   "destination": "processed",
   "directory": "cmslite_gdx",
-  "doc": "results_20180802.csv",
+  "doc": "cmslite.csv*",
   "dbschema": "cmslite",
   "dbtable": "metadata",
   "columns": ["NODE_ID","PARENT_NODE_ID","ANCESTOR_NODES","KEYWORDS","DESCRIPTION","PAGE_TYPE","SYNONYMS","DCTERMS_CREATOR","MODIFIED_DATE","CREATED_DATE","UPDATED_DATE","PUBLISHED_DATE","CONTENT_TYPES","MBCTERMS_SUBJECT_CATEGORIES","DCTERMS_SUBJECTS","DCTERMS_LANGUAGES","AUDIENCES","URL"],

--- a/microservices/cmslitemetadata_to_redshift/cmslitemetadata_to_redshift.py
+++ b/microservices/cmslitemetadata_to_redshift/cmslitemetadata_to_redshift.py
@@ -123,7 +123,6 @@ for object_summary in my_bucket.objects.filter(Prefix=source + "/" + directory +
 
         # Check to see if the file has been processed already
         batchfile = destination + "/batch/" + object_summary.key
-        # XX we have temporarily overriden the check for successfully processed files
         goodfile = destination + "/good/" + object_summary.key
         badfile = destination + "/bad/" + object_summary.key
         try:


### PR DESCRIPTION
Removed extraneous comment in `cmslitemetadata_to_redshift.py`, and updated `cmslite_gdx.json` to reflect accurate doc regex.