### PR TITLE
using pandas string attribute for string replacements

### DIFF
--- a/microservices/cmslitemetadata_to_redshift/cmslitemetadata_to_redshift.py
+++ b/microservices/cmslitemetadata_to_redshift/cmslitemetadata_to_redshift.py
@@ -177,7 +177,7 @@ for object_summary in my_bucket.objects.filter(Prefix=source + "/" + directory +
         # Run replace on some fields to clean the data up 
         if 'replace' in data:
             for thisfield in data['replace']:
-                df[thisfield['field']].replace(thisfield['old'], thisfield['new'])
+                df[thisfield['field']].str.replace(thisfield['old'], thisfield['new'])
 
         # Clean up date fields, for each field listed in the dateformat array named "field" apply "format"
         # Leaves null entries as blanks instead of NaT


### PR DESCRIPTION
In Python 2.7 you can't compare a unicode and a string with non-ascii characters directly. Attempting will result in a warning message:
```
/usr/local/lib64/python2.7/site-packages/pandas/core/missing.py:51: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  mask = arr == x
```
Following https://pandas.pydata.org/pandas-docs/stable/text.html#indexing-with-str.
Resolves this.