### PR TITLE
Updated the version and the .js of each tracker

### DIFF
--- a/web_trackers/Snowplow_inline_code.js
+++ b/web_trackers/Snowplow_inline_code.js
@@ -2,7 +2,7 @@
 ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
  p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
  };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
- n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/aubjyAzCUz7dJwqdbH3cMi45LjI.js","snowplow"));
+ n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
 var collector = 'spm.gov.bc.ca';
  window.snowplow('newTracker','rt',collector, {
   appId: "Snowplow_standalone",

--- a/web_trackers/Snowplow_inline_code.js
+++ b/web_trackers/Snowplow_inline_code.js
@@ -1,4 +1,4 @@
-// <!-- Snowplow starts plowing - Standalone v2.2.9.2 -->
+// <!-- Snowplow starts plowing - Standalone vA.2.10.2 -->
 ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
  p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
  };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;

--- a/web_trackers/Snowplow_inline_code_search.js
+++ b/web_trackers/Snowplow_inline_code_search.js
@@ -1,8 +1,8 @@
-// <!-- Snowplow starts plowing - Standalone Search v2.2.9.3 -->
+// <!-- Snowplow starts plowing - Standalone Search vA.2.10.2 -->
 ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
     p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
     };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
-    n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/aubjyAzCUz7dJwqdbH3cMi45LjI.js","snowplow"));
+    n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
 var collector = 'spm.gov.bc.ca';
 window.snowplow('newTracker','rt',collector, {
     appId: "Snowplow_standalone",

--- a/web_trackers/gov_search_sp_script.js
+++ b/web_trackers/gov_search_sp_script.js
@@ -1,8 +1,8 @@
-// <!-- Snowplow starts plowing - Search v2.2.9.2 -->
+// <!-- Snowplow starts plowing - Search vA.2.10.2 -->
 ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
     p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
     };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
-    n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/aubjyAzCUz7dJwqdbH3cMi45LjI.js","snowplow"));
+    n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
     var collector = 'spm.gov.bc.ca';
     window.snowplow('newTracker','rt',collector, {
         appId: "Snowplow_gov",

--- a/web_trackers/gov_sp_script.js
+++ b/web_trackers/gov_sp_script.js
@@ -1,8 +1,8 @@
-// <!-- Snowplow starts plowing - CMS Lite v2.2.9.2 -->
+// <!-- Snowplow starts plowing - CMS Lite vA.2.10.2 -->
 ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
  p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
  };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
- n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/aubjyAzCUz7dJwqdbH3cMi45LjI.js","snowplow"));
+ n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
  var collector = 'spm.gov.bc.ca';
  window.snowplow('newTracker','rt',collector, {
 	appId: "Snowplow_gov", 

--- a/web_trackers/wordpress_sp_script.js
+++ b/web_trackers/wordpress_sp_script.js
@@ -1,8 +1,8 @@
-// <!-- Snowplow starts plowing - Wordpress v2.2.9.2 -->
+// <!-- Snowplow starts plowing - Wordpress vA.2.10.2 -->
 ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
     p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
     };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
-    n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/aubjyAzCUz7dJwqdbH3cMi45LjI.js","snowplow"));
+    n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
 var collector = 'spm.gov.bc.ca';
 window.snowplow('newTracker','rt',collector, {
     appId: "Snowplow_engage",


### PR DESCRIPTION
I have updated the version to the new standard we agreed upon starting with A. I also updated the .js in the tracker from 2.9.2 to 2.10.2 and did a test on engage and the data is coming in correctly.

GDXDSD-1679