### PR TITLE
Update to workaround ssl CertificateError on pathfinder.bcgov hostnames

### DIFF
--- a/examples/CFMS_python_poc/README.md
+++ b/examples/CFMS_python_poc/README.md
@@ -4,12 +4,13 @@
 This code is a proof of concept of Python code required to add Snowplow instrumentation using the initial CFMS proof of concept model. For more information on the Snowplow Python Tracker see https://github.com/snowplow/snowplow-python-tracker.
 
 ### [call_analytics_openshift_gateway.py](./call_analytics_openshift_gateway.py)
-Sample Python script showing the structure of an example event, and the requirements to call the GDX Analytics OpenShift Snoplow Gateway service with that event data. See https://github.com/bcgov/GDX-Analytics-OpenShift-Snowplow-Gateway-Service
+Sample Python script showing the structure of an example event, and the requirements to call the GDX Analytics OpenShift Snowplow Gateway service with that event data. See https://github.com/bcgov/GDX-Analytics-OpenShift-Snowplow-Gateway-Service
 
-- [call_analytics_openshift_gateway.py](./call_analytics_openshift_gateway.py) creates a json object to POST to the GDX Analytics OpenShift Snoplow Gateway service. An example of the *kind* of JSON event that service can accept is also provided here as [post_data.json](./post_data.json). This file may be helpful for tests of the service using tools like [Postman](https://www.getpostman.com/) or [Insomnia](https://insomnia.rest/), or simply using cURL as:
+- [call_analytics_openshift_gateway.py](./call_analytics_openshift_gateway.py) based on dummy variables this creates an object as JSON and POSTs it to the hostname passed as an argument. This is used to simply test the GDX Analytics OpenShift Snowplow Gateway service. An example of the *kind* of JSON event that service can accept is also provided here as [post_data.json](./post_data.json). This file may be helpful for tests of the service using tools like [Postman](https://www.getpostman.com/) or [Insomnia](https://insomnia.rest/), or simply using cURL as:
 ```
 curl -vX POST <<hostname>> -d @post_data.json --header "Content-Type: application/json"
 ```
+You may require the `--insecure` flag on the above command if you need to skip certificate validation.
 
 ## Project Status
 
@@ -47,16 +48,16 @@ When connecting to Snowplow signed by a BC Government SSL certificate you may en
 ```
 WARNING:snowplow_tracker.emitters:[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:833)
 ```
-This occurs on some systems where your Python environment is missing the root certificate used to sign our SSL certificate. It appears that the Certificate Authority (CA) for Entrust is missing. 
+This occurs on some systems where your Python environment is missing the root certificate used to sign our SSL certificate. It appears that the Certificate Authority (CA) for Entrust is missing.
 
-You can test this on the main HTTPS certificate using an interactive Python session by running: 
+You can test this on the main HTTPS certificate using an interactive Python session by running:
 ```
 >>> import requests
 >>> requests.get('https://www2.gov.bc.ca')
 ```
 
-To work around this issue, download the CA from https://www.entrustdatacard.com/pages/root-certificates-download. 
-Look for the "Entrust Root Certificate Authority—G2" and dowload the certificate from https://entrust.com/root-certificates/entrust_g2_ca.cer. 
+To work around this issue, download the CA from https://www.entrustdatacard.com/pages/root-certificates-download.
+Look for the "Entrust Root Certificate Authority—G2" and download the certificate from https://entrust.com/root-certificates/entrust_g2_ca.cer.
 
 To ensure that Python loads this CA, can set this environment variable:
 ```
@@ -65,11 +66,11 @@ To ensure that Python loads this CA, can set this environment variable:
 
 ## Getting Help
 
-Please Contact dan.pollock@gov.bc.ca for questions related to this work. 
+Please Contact dan.pollock@gov.bc.ca for questions related to this work.
 
 ## Contributors
 
-The GDX analytics team will be the main contributors to this project currently. They will also maintain the code as well. 
+The GDX analytics team will be the main contributors to this project currently. They will also maintain the code as well.
 
 ## License
 
@@ -85,4 +86,3 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
-

--- a/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
+++ b/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
@@ -25,16 +25,20 @@ import time
 import json
 import sys
 import ssl
+from socket import gaierror
 
 # GDX Analytics as a Service address information
 # Prod: caps.pathfinder.gov.bc.ca
 # Test: test-caps.pathfinder.gov.bc.ca
 # Dev:  dev-caps.pathfinder.gov.bc.ca
 hostname = sys.argv[1]
+bcgov_hosts = ['caps.pathfinder.bcgov',
+               'test-caps.pathfinder.bcgov',
+               'dev-caps.pathfinder.bcgov']
 
 # hostport is only used if the listener app is running on 0.0.0.0.
 # do not specify a hostport if you a connecting to one of the Prod/Test/Dev routes
-if hostname not in ('caps.pathfinder.bcgov','test-caps.pathfinder.bcgov','dev-caps.pathfinder.bcgov'):
+if hostname not in bcgov_hosts:
     if len(sys.argv) is 3:
         hostport = sys.argv[2]
 
@@ -52,7 +56,11 @@ def post_event(json_event):
     headers = {'Content-type': 'application/json'}
 
     # Send a post request containing the event as JSON in the body
-    conn.request('POST', '/post', json_event, headers)
+    try:
+        conn.request('POST', '/post', json_event, headers)
+    except gaierror as e:
+        print("Failure getting address info. \nYour IP address may not be whitelisted to the listener.")
+        sys.exit(1)
 
 
     # Recieve the response


### PR DESCRIPTION
because hostnames '*.pathfinder.bcgov' don't match either of '*.pathfinder.gov.bc.ca', 'pathfinder.gov.bc.ca'; the OCP router SSL validation check throws an error on an HTTPSConnection. The context=ssl._create_unverified_context() overrides this SSL validation check and allows those routes to work.