### PR TITLE
Handle and log unicode exception on file read

### DIFF
--- a/microservices/s3_to_redshift/s3_to_redshift.py
+++ b/microservices/s3_to_redshift/s3_to_redshift.py
@@ -143,7 +143,7 @@ for object_summary in my_bucket.objects.filter(Prefix=source + "/"
         try:
             csv_string = body.read().decode('utf-8')
         except UnicodeDecodeError as e:
-            logger.error(''.join((
+            logger.exception(''.join((
                           "Decoding UTF-8 failed for file {0}\n{1}"
                           .format(object_summary.key, e.message),
                           "Keying to badfile and skipping.")))

--- a/microservices/s3_to_redshift/s3_to_redshift.py
+++ b/microservices/s3_to_redshift/s3_to_redshift.py
@@ -143,10 +143,14 @@ for object_summary in my_bucket.objects.filter(Prefix=source + "/"
         try:
             csv_string = body.read().decode('utf-8')
         except UnicodeDecodeError as e:
-            logger.exception(''.join((
-                          "Decoding UTF-8 failed for file {0}\n{1}"
-                          .format(object_summary.key, e.message),
-                          "Keying to badfile and skipping.")))
+            e_object = e.object.splitlines()
+            logger.exception(
+                ''.join((
+                    "Decoding UTF-8 failed for file {0}\n"
+                    .format(object_summary.key),
+                    "The input file stopped parsing after line {0}:\n{1}\n"
+                    .format(len(e_object), e_object[-1]),
+                    "Keying to badfile and skipping.\n")))
             try:
                 client.copy_object(
                     Bucket="sp-ca-bc-gov-131565110619-12-microservices",


### PR DESCRIPTION
Tested to work with a non-unicode character containing file on S3.

Writes as an exception log as:
```
Decoding UTF-8 failed for file path/to/file.csv
Keying to badfile and skipping.
```