### PR TITLE
introduce argparse support in openshift gateway calling script

### DIFF
--- a/examples/CFMS_python_poc/README.md
+++ b/examples/CFMS_python_poc/README.md
@@ -34,10 +34,13 @@ $ python sn.py
 
 To run [call_analytics_openshift_gateway.py](./call_analytics_openshift_gateway.py):
 ```
-$ python call_analytics_openshift_gateway.py <<hostname>> [<<hostport>>]
+$ python call_analytics_openshift_gateway.py [<<hostname>>] [<<hostport>>] [--insecure | -i] [--debug | -d]
 ```
-- Likely values for the `<<hostname>>` argument are `caps.pathfinder.gov.bc.ca` (the production OpenShift route) or `0.0.0.0` (if testing locally).
-- Likely values for the `[<<hostport>>]` optional argument are `8080` (if testing locally).
+- Passing no additional command line arguments when running `call_analytics_openshift_gateway.py` will result in the default hostname of `localhost` and the default port of `8443`
+- The optional flag `--insecure` will transmit the POST request insecurely over `http`. Otherwise, the message will be packaged as an `https` request.
+- The optional flag `--debug` is sets the logs to be at the `debug` level instead of the default `info` level.
+- Likely values for the `[<<hostname>>]` argument are `caps.pathfinder.gov.bc.ca` (the production OpenShift route) or `localhost` or `0.0.0.0` (if testing locally).
+- Likely values for the `[<<hostport>>]` optional argument are `8443` (if testing locally) or `443` if calling the service running on OpenShift.
 - Note that the GDX Analytics OpenShift Snowplow Gateway Service is currently whitelisted to allow only BC Government IP ranges (including the IP ranges for OpenShift itself).
 
 ## Special files in this repository
@@ -66,7 +69,7 @@ To ensure that Python loads this CA, can set this environment variable:
 
 ## Getting Help
 
-Please contact dan.pollock@gov.bc.ca for questions related to this work. 
+Please contact dan.pollock@gov.bc.ca for questions related to this work.
 
 ## Contributors
 

--- a/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
+++ b/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
@@ -44,7 +44,7 @@ parser.add_argument('hostport', nargs='?', help='CAPS Analytics host port.',
                     default='8443')
 parser.add_argument('-d', '--debug', help='Debug level logging.',
                     action="store_true")
-parser.add_argument('-s', '--https', help='Transmit data on https',
+parser.add_argument('-i', '--insecure', help='Transmit insecurely over HTTP',
                     action="store_true")
 args = parser.parse_args()
 
@@ -79,11 +79,11 @@ hostport = args.hostport
 # make the POST call that contains the event data
 def post_event(json_event):
     # Make the connection
-    if args.https:
+    if args.insecure:
+        conn = http.client.HTTPConnection(hostname)
+    else:
         conn = http.client.HTTPSConnection(
             hostname, context=ssl._create_unverified_context())
-    else:
-        conn = http.client.HTTPConnection(hostname)
     if hostport:
         conn.port = hostport
 

--- a/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
+++ b/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
@@ -14,9 +14,13 @@
 #               : then call the script from the command line:
 #               : $ python call_analytics.py <<hostname>> <<hostport>>
 #               :
-#               : For example :
-#            $ python call_analytics_openshift_gateway.py caps.pathfinder.bcgov
-#            $ python call_analytics_openshift_gateway.py localhost 8443
+# Examples      : This usage will call the default localhost on port 8443:
+#               : $ python call_analytics_openshift_gateway.py
+#               : This usage will call caps.pathfinder.bcgov on 8443 with debug
+#               : level logging:
+#         $ python call_analytics_openshift_gateway.py caps.pathfinder.bcgov -d
+#               : This usage will call localhost on port 443 using https
+#            $ python call_analytics_openshift_gateway.py localhost 443 -s
 #
 # References    :
 #     https://github.com/bcgov/GDX-Analytics-OpenShift-Snowplow-Gateway-Service
@@ -40,8 +44,7 @@ parser.add_argument('hostport', nargs='?', help='CAPS Analytics host port.',
                     default='8443')
 parser.add_argument('-d', '--debug', help='Debug level logging.',
                     action="store_true")
-parser.add_argument('-s', '--tls',
-                    help='Transmit data using transport layer security.',
+parser.add_argument('-s', '--https', help='Transmit data on https',
                     action="store_true")
 args = parser.parse_args()
 

--- a/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
+++ b/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
@@ -79,7 +79,7 @@ hostport = args.hostport
 # make the POST call that contains the event data
 def post_event(json_event):
     # Make the connection
-    if args.tls:
+    if args.https:
         conn = http.client.HTTPSConnection(
             hostname, context=ssl._create_unverified_context())
     else:

--- a/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
+++ b/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
@@ -14,11 +14,12 @@
 #               : then call the script from the command line:
 #               : $ python call_analytics.py <<hostname>> <<hostport>>
 #               :
-#               : For example:
-#               : $ python call_analytics_openshift_gateway.py caps.pathfinder.bcgov
-#               : $ python call_analytics_openshift_gateway.py localhost 8443
+#               : For example :
+#            $ python call_analytics_openshift_gateway.py caps.pathfinder.bcgov
+#            $ python call_analytics_openshift_gateway.py localhost 8443
 #
-# References    : https://github.com/bcgov/GDX-Analytics-OpenShift-Snowplow-Gateway-Service
+# References    :
+#     https://github.com/bcgov/GDX-Analytics-OpenShift-Snowplow-Gateway-Service
 
 import http.client
 import time
@@ -26,29 +27,60 @@ import json
 import sys
 import ssl
 from socket import gaierror
+import argparse
+import signal  # Dealing with Ctrl+C
+import logging
+
+# Arguments parsing
+parser = argparse.ArgumentParser(
+    description='Unix like tail command for Elastisearch and Snowplow.')
+parser.add_argument('hostname', nargs='?', help='CAPS Analytics host URL.',
+                    default='localhost')
+parser.add_argument('hostport', nargs='?', help='CAPS Analytics host port.',
+                    default='8443')
+parser.add_argument('-d', '--debug', help='Debug level logging.',
+                    action="store_true")
+parser.add_argument('-s', '--tls',
+                    help='Transmit data using transport layer security.',
+                    action="store_true")
+args = parser.parse_args()
+
+# Create stream handler for logs at the INFO level
+logger = logging.getLogger(__name__)
+formatter = logging.Formatter("%(asctime)s:[%(levelname)s]: %(message)s")
+if args.debug:
+    # Extend stream handler for logs at the DEBUG level
+    logger.setLevel(logging.DEBUG)
+    logger.debug("debug mode is on")
+else:
+    logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+
+# Ctrl+C
+def signal_handler(signal, frame):
+    logger.info('Ctrl+C pressed. Exiting.')
+    sys.exit(0)
+
+
+# Ctrl+C handler
+signal.signal(signal.SIGINT, signal_handler)
 
 # GDX Analytics as a Service address information
-# Prod: caps.pathfinder.gov.bc.ca
-# Test: test-caps.pathfinder.gov.bc.ca
-# Dev:  dev-caps.pathfinder.gov.bc.ca
-hostname = sys.argv[1]
-bcgov_hosts = ['caps.pathfinder.bcgov',
-               'test-caps.pathfinder.bcgov',
-               'dev-caps.pathfinder.bcgov']
-hostport = False
-
-# hostport is only used if the listener app is running on 0.0.0.0.
-# do not specify a hostport if you a connecting to one of the bcgov_hosts
-if hostname not in bcgov_hosts:
-    if len(sys.argv) == 3:
-        hostport = sys.argv[2]
+hostname = args.hostname
+hostport = args.hostport
 
 
 # make the POST call that contains the event data
 def post_event(json_event):
     # Make the connection
-    conn = http.client.HTTPSConnection(
-        hostname, context=ssl._create_unverified_context())
+    if args.tls:
+        conn = http.client.HTTPSConnection(
+            hostname, context=ssl._create_unverified_context())
+    else:
+        conn = http.client.HTTPConnection(hostname)
     if hostport:
         conn.port = hostport
 
@@ -58,19 +90,22 @@ def post_event(json_event):
     # Send a post request containing the event as JSON in the body
     try:
         conn.request('POST', '/post', json_event, headers)
-    except gaierror as e:
-        print("Failure getting address info. \nYour IP address may not be whitelisted to the listener.")
+    except gaierror:
+        logger.exception(
+            ("Failure getting address info. "
+             "Your IP address may not be whitelisted to the listener."))
         sys.exit(1)
-
 
     # Recieve the response
     try:
         response = conn.getresponse()
-    except http.client.ResponseNotReady as e:
-        print("ResponseNotReady Exception")
+    except http.client.ResponseNotReady:
+        logger.exception("ResponseNotReady Exception")
         sys.exit(1)
     # Print the response
-    print(response.status, response.reason)
+    logger.info('status: {} reason: {}'.format(
+        response.status, response.reason))
+
 
 # schema is a string to the iglu:ca.bc.gov schema for this event
 # context is the list of contexts as dictionaries for this event
@@ -79,109 +114,99 @@ def event(schema, contexts, data):
     post_body = configuration
     post_body['dvce_created_tstamp'] = event_timestamp()
     post_body['event_data_json'] = {
-        'contexts':contexts,
-        'data':data,
-        'schema':schema
-    }
+        'contexts': contexts,
+        'data': data,
+        'schema': schema}
     return post_body
+
 
 # time of event as an epoch timestamp in milliseconds
 def event_timestamp():
-    # time.time() returns the time in seconds with 6 decimal places of precision
+    # time.time() returns the time in seconds with 6 decimal places
     return int(round(time.time() * 1000))
 
-def get_citizen(client_id,service_count,quick_txn,schema):
+
+def get_citizen(client_id, service_count, quick_txn, schema):
     # Set up the citizen context.
     citizen = {
-        'data':
-        {
+        'data': {
             'client_id': client_id,
             'service_count': service_count,
-            'quick_txn': quick_txn
-        },
-        'schema':schema
-    }
+            'quick_txn': quick_txn},
+        'schema': schema}
     return citizen
 
-def get_office(office_id,office_type,schema):
+
+def get_office(office_id, office_type, schema):
     # Set up the office context.
     office = {
-        'data':
-        {
+        'data': {
             'office_id': office_id,
-            'office_type': office_type
-        },
-        'schema':schema
-    }
+            'office_type': office_type},
+        'schema': schema}
     return office
 
-def get_agent(agent_id,role,quick_txn,schema):
+
+def get_agent(agent_id, role, quick_txn, schema):
     # Set up the service context.
     agent = {
-        'data':
-        {
+        'data': {
             'agent_id': agent_id,
             'role': role,
-            'quick_txn': quick_txn
-        },
-        'schema':schema
-    }
+            'quick_txn': quick_txn},
+        'schema': schema}
     return agent
+
 
 # Prepare the event requirements
 configuration = {
-    'env':'test', # test or prod
-    'namespace':'GDX-OpenShift-Test',
-    'app_id':'GDX-OpenShift-Test'
-}
+    'env': 'test',  # test or prod
+    'namespace': 'GDX-OpenShift-Test',
+    'app_id': 'GDX-OpenShift-Test'}
 
 # Example values contexts
-## citizen
-citizen_schema='iglu:ca.bc.gov.cfmspoc/citizen/jsonschema/3-0-0'
-client_id=283732
-service_count=15
-quick_txn=False
-## office
-office_schema='iglu:ca.bc.gov.cfmspoc/office/jsonschema/1-0-0'
-office_id=14
-office_type='reception'
-## agent
-agent_schema='iglu:ca.bc.gov.cfmspoc/agent/jsonschema/2-0-0'
-agent_id=99
-role='CSR'
-quick_txn=False
+# citizen
+citizen_schema = 'iglu:ca.bc.gov.cfmspoc/citizen/jsonschema/3-0-0'
+client_id = 283732
+service_count = 15
+quick_txn = False
+# office
+office_schema = 'iglu:ca.bc.gov.cfmspoc/office/jsonschema/1-0-0'
+office_id = 14
+office_type = 'reception'
+# agent
+agent_schema = 'iglu:ca.bc.gov.cfmspoc/agent/jsonschema/2-0-0'
+agent_id = 99
+role = 'CSR'
+quick_txn = False
 
 citizen = get_citizen(
     client_id=client_id,
     service_count=service_count,
     quick_txn=quick_txn,
-    schema=citizen_schema
-)
+    schema=citizen_schema)
 
 office = get_office(
     office_id=office_id,
     office_type=office_type,
-    schema=office_schema
-)
+    schema=office_schema)
 
 agent = get_agent(
     agent_id=agent_id,
     role=role,
     quick_txn=quick_txn,
-    schema=agent_schema
-)
+    schema=agent_schema)
 
-contexts = [citizen,office,agent]
+contexts = [citizen, office, agent]
 
 # Example schema and data for a 'finish' event
 schema = 'iglu:ca.bc.gov.cfmspoc/finish/jsonschema/2-0-0'
 data = {
     'inaccurate_time': False,
-    'quantity': 66
-}
+    'quantity': 66}
 
 # create example event
-example_event = event(schema,contexts,data)
+example_event = event(schema, contexts, data)
 
 # Create a JSON object from the event dictionary
 json_event = json.dumps(example_event)

--- a/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
+++ b/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
@@ -101,7 +101,6 @@ def post_event(json_event):
              "Your IP address may not be whitelisted to the listener."))
         sys.exit(1)
 
-    time.sleep(3)
     # Recieve the response
     try:
         response = conn.getresponse()

--- a/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
+++ b/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
@@ -20,7 +20,7 @@
 #               : level logging:
 #         $ python call_analytics_openshift_gateway.py caps.pathfinder.bcgov -d
 #               : This usage will call localhost on port 443 using https
-#            $ python call_analytics_openshift_gateway.py localhost 443 -s
+#            $ python call_analytics_openshift_gateway.py localhost 443 -i
 #
 # References    :
 #     https://github.com/bcgov/GDX-Analytics-OpenShift-Snowplow-Gateway-Service
@@ -78,14 +78,16 @@ hostport = args.hostport
 
 # make the POST call that contains the event data
 def post_event(json_event):
+    logger.debug("posting json:\n{}".format(json_event))
     # Make the connection
     if args.insecure:
+        logger.info("Preparing insecure connection http://{}".format(hostname))
         conn = http.client.HTTPConnection(hostname)
     else:
+        logger.info("Preparing secure connection https://{}".format(hostname))
         conn = http.client.HTTPSConnection(
             hostname, context=ssl._create_unverified_context())
-    if hostport:
-        conn.port = hostport
+    conn.port = hostport
 
     # Prepare the headers
     headers = {'Content-type': 'application/json'}
@@ -99,6 +101,7 @@ def post_event(json_event):
              "Your IP address may not be whitelisted to the listener."))
         sys.exit(1)
 
+    time.sleep(3)
     # Recieve the response
     try:
         response = conn.getresponse()


### PR DESCRIPTION
Since introducing the option to support TLS as an optional attribute for the OpenShift snowplow analytics gateway server application, this caller script used to test basic functionality of that server also required optional HTTPS support.