### PR TITLE
Suppress google direction metrics response output to file

### DIFF
--- a/microservices/google-api/google_directions.py
+++ b/microservices/google-api/google_directions.py
@@ -357,8 +357,10 @@ for account in validated_accounts:
     # The stiched_responses now contains all location driving direction data
     # as a list of dictionaries keyed to 'locationDrivingDirectionMetrics'.
     # The next block will build a dataframe from this list for CSV ouput to S3
-    file = open("LocationDrivingDirectionMetrics.json", "w+")
-    json.dump(stitched_responses, file, indent=2)
+
+    # Write out a file containing the stiched response from the queries above
+    # file = open("LocationDrivingDirectionMetrics.json", "w+")
+    # json.dump(stitched_responses, file, indent=2)
 
     # location_region_rows will collect elements from the API response
     # JSON into a list of dicts, to normalize into a DataFrame later


### PR DESCRIPTION
This step of creating a file that contained the stitched driving directions responses from the earlier loop had been left in from earlier reviews and testing.

It is no longer required, but the code may be useful to have commented out for later reviews.

@danpollock please review.