### PR TITLE
Update call_analytics_openshift_gateway.py

### DIFF
--- a/examples/CFMS_python_poc/README.md
+++ b/examples/CFMS_python_poc/README.md
@@ -36,7 +36,7 @@ To run [call_analytics_openshift_gateway.py](./call_analytics_openshift_gateway.
 ```
 $ python call_analytics_openshift_gateway.py [<<hostname>>] [<<hostport>>] [<<snowplow_endpoint>>] [--insecure | -i] [--debug | -d]
 ```
-- Passing no additional command line arguments when running `call_analytics_openshift_gateway.py` will result in the default hostname of `localhost`, the default port of `8443`, and the default endpoint as `prod`.
+- Passing no additional command line arguments when running `call_analytics_openshift_gateway.py` will result in the default hostname of `localhost`, the default port of `8443`, and the default endpoint as `test`.
 - the `<<snowplow_endpoint>>` options are `test` or `prod`. This is the string that populates the value for the `'env'` key in the POST body request JSON payload.
 - The optional flag `--insecure` will transmit the POST request insecurely over `http`. Otherwise, the message will be packaged as an `https` request.
 - The optional flag `--debug` is sets the logs to be at the `debug` level instead of the default `info` level.

--- a/examples/CFMS_python_poc/README.md
+++ b/examples/CFMS_python_poc/README.md
@@ -34,9 +34,10 @@ $ python sn.py
 
 To run [call_analytics_openshift_gateway.py](./call_analytics_openshift_gateway.py):
 ```
-$ python call_analytics_openshift_gateway.py [<<hostname>>] [<<hostport>>] [--insecure | -i] [--debug | -d]
+$ python call_analytics_openshift_gateway.py [<<hostname>>] [<<hostport>>] [<<snowplow_endpoint>>] [--insecure | -i] [--debug | -d]
 ```
-- Passing no additional command line arguments when running `call_analytics_openshift_gateway.py` will result in the default hostname of `localhost` and the default port of `8443`
+- Passing no additional command line arguments when running `call_analytics_openshift_gateway.py` will result in the default hostname of `localhost`, the default port of `8443`, and the default endpoint as `prod`.
+- the `<<snowplow_endpoint>>` options are `test` or `prod`. This is the string that populates the value for the `'env'` key in the POST body request JSON payload.
 - The optional flag `--insecure` will transmit the POST request insecurely over `http`. Otherwise, the message will be packaged as an `https` request.
 - The optional flag `--debug` is sets the logs to be at the `debug` level instead of the default `info` level.
 - Likely values for the `[<<hostname>>]` argument are `caps.pathfinder.gov.bc.ca` (the production OpenShift route) or `localhost` or `0.0.0.0` (if testing locally).

--- a/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
+++ b/examples/CFMS_python_poc/call_analytics_openshift_gateway.py
@@ -42,6 +42,8 @@ parser.add_argument('hostname', nargs='?', help='CAPS Analytics host URL.',
                     default='localhost')
 parser.add_argument('hostport', nargs='?', help='CAPS Analytics host port.',
                     default='8443')
+parser.add_argument('endpoint', nargs='?', help='Snowplow endpoint.',
+                    default='test')
 parser.add_argument('-d', '--debug', help='Debug level logging.',
                     action="store_true")
 parser.add_argument('-i', '--insecure', help='Transmit insecurely over HTTP',
@@ -74,6 +76,7 @@ signal.signal(signal.SIGINT, signal_handler)
 # GDX Analytics as a Service address information
 hostname = args.hostname
 hostport = args.hostport
+endpoint = args.endpoint
 
 
 # make the POST call that contains the event data
@@ -165,7 +168,7 @@ def get_agent(agent_id, role, quick_txn, schema):
 
 # Prepare the event requirements
 configuration = {
-    'env': 'test',  # test or prod
+    'env': '{}'.format(endpoint),  # test or prod
     'namespace': 'GDX-OpenShift-Test',
     'app_id': 'GDX-OpenShift-Test'}
 


### PR DESCRIPTION
Allows specifying the endpoint for snowplow as test or prod from the command line