### PR TITLE
page_urlhost in google_search microservice to build from page

### DIFF
--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -375,7 +375,7 @@ GRANT SELECT ON cmslite.google_pdt_scratch TO looker;
 INSERT INTO cmslite.google_pdt_scratch
       SELECT gs.*,
       COALESCE(node_id,'') AS node_id,
-      SPLIT_PART(site, '/',3) as page_urlhost,
+      SPLIT_PART(page, '/',3) as page_urlhost,
       title,
       theme_id, subtheme_id, topic_id, theme, subtheme, topic
       FROM google.googlesearch AS gs


### PR DESCRIPTION
instead of site.

@danpollock testing on this same change was done in the search_domain_properties branch documented in GDXDSD-2518 on Jira.