### PR TITLE
Collector update GDXDSD-2727

### DIFF
--- a/examples/google_maps_tracker/google_maps_tracking_example.html
+++ b/examples/google_maps_tracker/google_maps_tracking_example.html
@@ -16,7 +16,7 @@
         p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
         n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
-        var collector = 'spm.gov.bc.ca';
+        var collector = 'spm.apps.gov.bc.ca';
         window.snowplow('newTracker','rt',collector, {
             appId: "Snowplow_standalone",
             platform: 'web',

--- a/examples/html_example/index.html
+++ b/examples/html_example/index.html
@@ -38,8 +38,8 @@ jQuery(document).ready(function() {
     ;(function(p,l,o,w,i,n,g){if(!p[i]){p.GlobalSnowplowNamespace=p.GlobalSnowplowNamespace||[];
     p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
     };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
-    n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/aubjyAzCUz7dJwqdbH3cMi45LjI.js","snowplow"));
-    var collector = 'spm.gov.bc.ca';
+    n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
+    var collector = 'spm.apps.gov.bc.ca';
     window.snowplow('newTracker','rt',collector, {
         appId: "Snowplow_standalone",
         platform: 'web',

--- a/examples/youtube_tracker/youtube_tracking_example.html
+++ b/examples/youtube_tracker/youtube_tracking_example.html
@@ -10,7 +10,7 @@
         p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
         n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
-        var collector = 'spm.gov.bc.ca';
+        var collector = 'spm.apps.gov.bc.ca';
         window.snowplow('newTracker','rt',collector, {
             appId: "Snowplow_standalone",
             platform: 'web',

--- a/web_trackers/Snowplow_inline_code.js
+++ b/web_trackers/Snowplow_inline_code.js
@@ -3,7 +3,7 @@
  p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
  };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
  n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
-var collector = 'spm.gov.bc.ca';
+var collector = 'spm.apps.gov.bc.ca';
  window.snowplow('newTracker','rt',collector, {
   appId: "Snowplow_standalone",
   platform: 'web',

--- a/web_trackers/Snowplow_inline_code_search.js
+++ b/web_trackers/Snowplow_inline_code_search.js
@@ -3,7 +3,7 @@
     p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
     };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
     n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
-var collector = 'spm.gov.bc.ca';
+var collector = 'spm.apps.gov.bc.ca';
 window.snowplow('newTracker','rt',collector, {
     appId: "Snowplow_standalone",
     platform: 'web',

--- a/web_trackers/gov_search_sp_script.js
+++ b/web_trackers/gov_search_sp_script.js
@@ -3,7 +3,7 @@
     p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
     };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
     n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
-    var collector = 'spm.gov.bc.ca';
+    var collector = 'spm.apps.gov.bc.ca';
     window.snowplow('newTracker','rt',collector, {
         appId: "Snowplow_gov",
         platform: 'web',

--- a/web_trackers/gov_sp_script.js
+++ b/web_trackers/gov_sp_script.js
@@ -3,7 +3,7 @@
  p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
  };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
  n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
- var collector = 'spm.gov.bc.ca';
+ var collector = 'spm.apps.gov.bc.ca';
  window.snowplow('newTracker','rt',collector, {
 	appId: "Snowplow_gov", 
 	platform: 'web',

--- a/web_trackers/wordpress_sp_script.js
+++ b/web_trackers/wordpress_sp_script.js
@@ -3,7 +3,7 @@
     p.GlobalSnowplowNamespace.push(i);p[i]=function(){(p[i].q=p[i].q||[]).push(arguments)
     };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
     n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://sp-js.apps.gov.bc.ca/MDWay3UqFnIiGVLIo7aoMi4xMC4y.js","snowplow"));
-var collector = 'spm.gov.bc.ca';
+var collector = 'spm.apps.gov.bc.ca';
 window.snowplow('newTracker','rt',collector, {
     appId: "Snowplow_engage",
     platform: 'web',


### PR DESCRIPTION
updating the snowplow mini collector from spm.gov.bc.ca to spm.apps.gov.bc.ca. I have tested this on a html page on my computer. This didn't change the collector in the health link search tracker, Brendan will be doing that.