### PR TITLE
Delete requirements.txt from google-api

### DIFF
--- a/microservices/google-api/requirements.txt
+++ b/microservices/google-api/requirements.txt
@@ -1,7 +1,0 @@
-boto3==1.9.159
-pandas==0.24.2
-botocore==1.12.159
-httplib2==0.13.0
-psycopg2==2.8.2
-google_api_python_client==1.7.11
-python_dateutil==2.8.0


### PR DESCRIPTION
No longer required, Pipenv handles dependencies in Pipfile.