### PR TITLE
Add TRUNCATECOLUMNS to COPY command

### DIFF
--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -341,7 +341,7 @@ for site_item in config_sites:
              "CREDENTIALS 'aws_access_key_id={AWS_ACCESS_KEY_ID};"
              "aws_secret_access_key={AWS_SECRET_ACCESS_KEY}' "
              "IGNOREHEADER AS 1 MAXERROR AS 0 DELIMITER '|' "
-             "NULL AS '-' ESCAPE;")
+             "NULL AS '-' ESCAPE TRUNCATECOLUMNS;")
         query = logquery.format(
             AWS_ACCESS_KEY_ID=os.environ['AWS_ACCESS_KEY_ID'],
             AWS_SECRET_ACCESS_KEY=os.environ['AWS_SECRET_ACCESS_KEY'])


### PR DESCRIPTION
TRUNCATECOLUMNS is a COPY option that converts the strings in the source data to the data type of the target column.

TRUNCATECOLUMNS Truncates CHAR or VARCHAR data in columns to the appropriate number of characters so that it fits the column specification.

https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-conversion.html#copy-truncatecolumns