### PR TITLE
Add STDOUT reporting to google_search.py microservice

### DIFF
--- a/microservices/google-api/Pipfile
+++ b/microservices/google-api/Pipfile
@@ -11,6 +11,8 @@ python-language-server = {extras = ["all"],version = "*"}
 [packages]
 apiclient = "*"
 backoff = "*"
+pytz = "*"
+tzlocal = "*"
 boto3 = "*"
 pandas = "*"
 botocore = "*"

--- a/microservices/google-api/google_search.json
+++ b/microservices/google-api/google_search.json
@@ -2,47 +2,47 @@
   "bucket": "sp-ca-bc-gov-131565110619-12-microservices",
   "source": "client",
   "destination": "processed",
-  "directory": "google_gdx_gdxdsd_3346",
-  "dbtable": "google.googlesearch_gdxdsd3346",
+  "directory": "google_gdx",
+  "dbtable": "google.googlesearch",
   "sites": [
     {
       "name": "https://www2.gov.bc.ca/"
     },
     {
       "name": "https://efficiencybc.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2019-03-02"
     },
     {
       "name": "https://news.gov.bc.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2017-12-09"
     },
     {
        "name":"https://betterhomesbc.ca/",
-       "start_date_default":"2021-01-12"
+       "start_date_default":"2019-05-21"
     },
     {
        "name":"https://betterbuildingsbc.ca/",
-       "start_date_default":"2021-01-12"
+       "start_date_default":"2019-05-21"
     },
     {
       "name":"https://studentsuccess.gov.bc.ca/",
-      "start_date_default":"2021-01-12"
+      "start_date_default":"2019-07-31"
     },
     {
       "name":"https://curriculum.gov.bc.ca/",
-      "start_date_default":"2021-01-12"
+      "start_date_default":"2018-04-04"
     },
     {
       "name":"sc-domain:engage.gov.bc.ca",
-      "start_date_default":"2021-01-12"
+      "start_date_default":"2018-09-16"
     },
     {
       "name":"https://bcforhighschool.gov.bc.ca/",
-      "start_date_default":"2021-01-12"
+      "start_date_default":"2019-09-05"
     },
     {
       "name":"https://rightforyou.workbc.ca/",
-      "start_date_default":"2021-01-12"
+      "start_date_default":"2020-01-20"
     },
     {
       "name": "http://www.bccdc.ca/"
@@ -52,66 +52,66 @@
     },
     {
       "name": "sc-domain:thrive.health",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2019-06-13"
     },
     {
       "name": "https://www.healthlinkbc.ca"
     },
     {
       "name": "https://www.workbc.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2020-04-23"
     },
     {
       "name": "https://www.costofliving.workbc.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2020-04-23"
     },
     {
       "name": "https://www.careertrekbc.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2020-04-23"
     },
     {
       "name": "https://www.britishcolumbia.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2019-02-02"
     },
     {
       "name": "https://www.britishcolumbia.kr/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2019-02-02"
     },
     {
       "name": "https://www.britishcolumbia.jp/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2019-02-02"
     },
     {
       "name": "https://www.british-columbia.cn/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2019-02-02"
     },
     {
       "name": "https://energystepcode.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2020-08-12"
     },
     {
       "name": "https://www.justicebc.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2020-09-09"
     },
     {
       "name": "https://www.bcmhrb.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2020-09-14"
     },
     {
       "name": "https://iiobc.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2020-09-14"
     },
     {
       "name": "https://professionalgovernancebc.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2020-09-14"
     },
     {
       "name": "https://www.welcomebc.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2020-08-16"
     },
     {
       "name": "https://www.responsibleservicebc.gov.bc.ca/",
-      "start_date_default": "2021-01-12"
+      "start_date_default": "2020-12-23"
     }
 
   ]

--- a/microservices/google-api/google_search.json
+++ b/microservices/google-api/google_search.json
@@ -2,7 +2,7 @@
   "bucket": "sp-ca-bc-gov-131565110619-12-microservices",
   "source": "client",
   "destination": "processed",
-  "directory": "google_gdx_GDXDSD_3346",
+  "directory": "google_gdx_gdxdsd_3346",
   "dbtable": "google.googlesearch_gdxdsd3346",
   "sites": [
     {

--- a/microservices/google-api/google_search.json
+++ b/microservices/google-api/google_search.json
@@ -12,6 +12,10 @@
     {
       "name": "https://betterbuildingsbc.ca/",
       "start_date_default": "2021-01-01"
+    },
+    {
+      "name": "https://doesnot3x1stq.ca/",
+      "start_date_default": "2021-01-01"
     }
   ]
 }

--- a/microservices/google-api/google_search.json
+++ b/microservices/google-api/google_search.json
@@ -6,16 +6,113 @@
   "dbtable": "google.googlesearch_gdxdsd3346",
   "sites": [
     {
+      "name": "https://www2.gov.bc.ca/"
+    },
+    {
       "name": "https://efficiencybc.ca/",
-      "start_date_default": "2021-01-01"
+      "start_date_default": "2021-01-12"
     },
     {
-      "name": "https://betterbuildingsbc.ca/",
-      "start_date_default": "2021-01-01"
+      "name": "https://news.gov.bc.ca/",
+      "start_date_default": "2021-01-12"
     },
     {
-      "name": "https://doesnot3x1stq.ca/",
-      "start_date_default": "2021-01-01"
+       "name":"https://betterhomesbc.ca/",
+       "start_date_default":"2021-01-12"
+    },
+    {
+       "name":"https://betterbuildingsbc.ca/",
+       "start_date_default":"2021-01-12"
+    },
+    {
+      "name":"https://studentsuccess.gov.bc.ca/",
+      "start_date_default":"2021-01-12"
+    },
+    {
+      "name":"https://curriculum.gov.bc.ca/",
+      "start_date_default":"2021-01-12"
+    },
+    {
+      "name":"sc-domain:engage.gov.bc.ca",
+      "start_date_default":"2021-01-12"
+    },
+    {
+      "name":"https://bcforhighschool.gov.bc.ca/",
+      "start_date_default":"2021-01-12"
+    },
+    {
+      "name":"https://rightforyou.workbc.ca/",
+      "start_date_default":"2021-01-12"
+    },
+    {
+      "name": "http://www.bccdc.ca/"
+    },
+    {
+      "name": "sc-domain:gov.bc.ca"
+    },
+    {
+      "name": "sc-domain:thrive.health",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://www.healthlinkbc.ca"
+    },
+    {
+      "name": "https://www.workbc.ca/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://www.costofliving.workbc.ca/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://www.careertrekbc.ca/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://www.britishcolumbia.ca/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://www.britishcolumbia.kr/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://www.britishcolumbia.jp/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://www.british-columbia.cn/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://energystepcode.ca/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://www.justicebc.ca/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://www.bcmhrb.ca/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://iiobc.ca/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://professionalgovernancebc.ca/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://www.welcomebc.ca/",
+      "start_date_default": "2021-01-12"
+    },
+    {
+      "name": "https://www.responsibleservicebc.gov.bc.ca/",
+      "start_date_default": "2021-01-12"
     }
+
   ]
 }

--- a/microservices/google-api/google_search.json
+++ b/microservices/google-api/google_search.json
@@ -2,113 +2,16 @@
   "bucket": "sp-ca-bc-gov-131565110619-12-microservices",
   "source": "client",
   "destination": "processed",
-  "directory": "google_gdx",
-  "dbtable": "google.googlesearch",
+  "directory": "google_gdx_GDXDSD_3346",
+  "dbtable": "google.googlesearch_gdxdsd3346",
   "sites": [
     {
-      "name": "https://www2.gov.bc.ca/"
-    },
-    {
       "name": "https://efficiencybc.ca/",
-      "start_date_default": "2019-03-02"
+      "start_date_default": "2021-01-01"
     },
     {
-      "name": "https://news.gov.bc.ca/",
-      "start_date_default": "2017-12-09"
-    },
-    {
-       "name":"https://betterhomesbc.ca/",
-       "start_date_default":"2019-05-21"
-    },
-    {
-       "name":"https://betterbuildingsbc.ca/",
-       "start_date_default":"2019-05-21"
-    },
-    {
-      "name":"https://studentsuccess.gov.bc.ca/",
-      "start_date_default":"2019-07-31"
-    },
-    {
-      "name":"https://curriculum.gov.bc.ca/",
-      "start_date_default":"2018-04-04"
-    },
-    {
-      "name":"sc-domain:engage.gov.bc.ca",
-      "start_date_default":"2018-09-16"
-    },
-    {
-      "name":"https://bcforhighschool.gov.bc.ca/",
-      "start_date_default":"2019-09-05"
-    },
-    {
-      "name":"https://rightforyou.workbc.ca/",
-      "start_date_default":"2020-01-20"
-    },
-    {
-      "name": "http://www.bccdc.ca/"
-    },
-    {
-      "name": "sc-domain:gov.bc.ca"
-    },
-    {
-      "name": "sc-domain:thrive.health",
-      "start_date_default": "2019-06-13"
-    },
-    {
-      "name": "https://www.healthlinkbc.ca"
-    },
-    {
-      "name": "https://www.workbc.ca/",
-      "start_date_default": "2020-04-23"
-    },
-    {
-      "name": "https://www.costofliving.workbc.ca/",
-      "start_date_default": "2020-04-23"
-    },
-    {
-      "name": "https://www.careertrekbc.ca/",
-      "start_date_default": "2020-04-23"
-    },
-    {
-      "name": "https://www.britishcolumbia.ca/",
-      "start_date_default": "2019-02-02"
-    },
-    {
-      "name": "https://www.britishcolumbia.kr/",
-      "start_date_default": "2019-02-02"
-    },
-    {
-      "name": "https://www.britishcolumbia.jp/",
-      "start_date_default": "2019-02-02"
-    },
-    {
-      "name": "https://www.british-columbia.cn/",
-      "start_date_default": "2019-02-02"
-    },
-    {
-      "name": "https://energystepcode.ca/",
-      "start_date_default": "2020-08-12"
-    },
-    {
-      "name": "https://www.justicebc.ca/",
-      "start_date_default": "2020-09-09"
-    },
-    {
-      "name": "https://www.bcmhrb.ca/",
-      "start_date_default": "2020-09-14"
-    },
-    {
-      "name": "https://iiobc.ca/",
-      "start_date_default": "2020-09-14"
-    },
-    {
-      "name": "https://professionalgovernancebc.ca/",
-      "start_date_default": "2020-09-14"
-    },
-    {
-      "name": "https://www.welcomebc.ca/",
-      "start_date_default": "2020-08-16"
+      "name": "https://betterbuildingsbc.ca/",
+      "start_date_default": "2021-01-01"
     }
-
   ]
 }

--- a/microservices/google-api/google_search.json
+++ b/microservices/google-api/google_search.json
@@ -109,6 +109,5 @@
       "name": "https://www.welcomebc.ca/",
       "start_date_default": "2020-08-16"
     }
-
   ]
 }

--- a/microservices/google-api/google_search.json
+++ b/microservices/google-api/google_search.json
@@ -108,10 +108,6 @@
     {
       "name": "https://www.welcomebc.ca/",
       "start_date_default": "2020-08-16"
-    },
-    {
-      "name": "https://www.responsibleservicebc.gov.bc.ca/",
-      "start_date_default": "2020-12-23"
     }
 
   ]

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -618,9 +618,9 @@ with psycopg2.connect(conn_string) as conn:
             curs.execute(query)
         except psycopg2.Error:
             logger.exception("Google Search PDT loading failed")
-            report_stats['pdt_build_succcess'] = True
             clean_exit(1,'Could not rebuild PDT in Redshift.')
         else:
+            report_stats['pdt_build_success'] = True
             logger.debug("Google Search PDT loaded successfully")
             clean_exit(0,'Finished succesfully.')
 

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -79,12 +79,14 @@ from googleapiclient.errors import HttpError as GoogleHttpError
 import psycopg2  # For Amazon Redshift IO
 import lib.logs as log
 
-# Get script start time
+# Get script start times
 local_tz = get_localzone()
 yvr_tz = timezone('America/Vancouver')
 yvr_dt_start = (yvr_tz
     .normalize(datetime.now(local_tz)
     .astimezone(yvr_tz)))
+# Set again at PDT build start time
+yvr_dt_pdt_start = ()
 
 # Ctrl+C
 def signal_handler(sig, frame):

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -240,8 +240,14 @@ def report(data):
     print(f'Successful API calls: {data["retrieved"]}')
     print(f'Failed API calls: {data["failed"]}')
     print(f'Objects loaded to S3 and copied to RedShift: {data["processed"]}')
-    print(f'List of objects that failed to copy to Redshift: {data["failed_to_rs"]}')
-    print(f'List of objects that were not processed due to early exit: {data["failed_api_call"]}')
+    if not data['processed']:
+        print('None')
+    else:
+        print(f'List of objects that failed to copy to Redshift: {data["failed_to_rs"]}')
+    if not data['failed_to_rs']:
+        print('None')
+    else:
+        print(f'List of objects that were not processed due to early exit: {data["failed_api_call"]}')
 
 
 # Reporting variables. Accumulates as the the sites listed in google_search.json are looped over

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -241,10 +241,13 @@ def report(data):
     print(f'Failed API calls: {data["failed"]}')
     print(f'Objects loaded to S3 and copied to RedShift: {data["processed"]}')
     if not data['processed']:
+        print(f'List of objects that failed to copy to Redshift:')
         print('None')
     else:
         print(f'List of objects that failed to copy to Redshift: {data["failed_to_rs"]}')
+
     if not data['failed_to_rs']:
+        print(f'List of objects that were not processed due to early exit:')
         print('None')
     else:
         print(f'List of objects that were not processed due to early exit: {data["failed_api_call"]}')

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -543,85 +543,85 @@ yvr_dt_pdt_start = (yvr_tz
     .normalize(datetime.now(local_tz)
     .astimezone(yvr_tz)))
 
-# # This query will INSERT data that is the result of a JOIN into
-# # cmslite.google_pdt, a persistent dereived table which facilitating the LookML
-# query = """
-# -- perform this as a transaction.
-# -- Either the whole query completes, or it leaves the old table intact
-# BEGIN;
-# DROP TABLE IF EXISTS cmslite.google_pdt;
+# This query will INSERT data that is the result of a JOIN into
+# cmslite.google_pdt, a persistent dereived table which facilitating the LookML
+query = """
+-- perform this as a transaction.
+-- Either the whole query completes, or it leaves the old table intact
+BEGIN;
+DROP TABLE IF EXISTS cmslite.google_pdt;
 
-# CREATE TABLE IF NOT EXISTS cmslite.google_pdt (
-#         site              VARCHAR(255)    ENCODE ZSTD,
-#         date              date            ENCODE AZ64,
-#         query             VARCHAR(2048)   ENCODE ZSTD,
-#         country           VARCHAR(255)    ENCODE ZSTD,
-#         device            VARCHAR(255)    ENCODE ZSTD,
-#         page              VARCHAR(2047)   ENCODE ZSTD,
-#         position          FLOAT           ENCODE ZSTD,
-#         clicks            DECIMAL         ENCODE ZSTD,
-#         ctr               FLOAT           ENCODE ZSTD,
-#         impressions       DECIMAL         ENCODE ZSTD,
-#         node_id           VARCHAR(255)    ENCODE ZSTD,
-#         page_urlhost      VARCHAR(255)    ENCODE ZSTD,
-#         title             VARCHAR(2047)   ENCODE ZSTD,
-#         theme_id          VARCHAR(255)    ENCODE ZSTD,
-#         subtheme_id       VARCHAR(255)    ENCODE ZSTD,
-#         topic_id          VARCHAR(255)    ENCODE ZSTD,
-#         subtopic_id       VARCHAR(255)    ENCODE ZSTD,
-#         subsubtopic_id    VARCHAR(255)    ENCODE ZSTD,
-#         theme             VARCHAR(2047)   ENCODE ZSTD,
-#         subtheme          VARCHAR(2047)   ENCODE ZSTD,
-#         topic             VARCHAR(2047)   ENCODE ZSTD,
-#         subtopic          VARCHAR(2047)   ENCODE ZSTD,
-#         subsubtopic       VARCHAR(2047)   ENCODE ZSTD)
-#         COMPOUND SORTKEY (date,page_urlhost,theme,page,clicks);
+CREATE TABLE IF NOT EXISTS cmslite.google_pdt (
+        site              VARCHAR(255)    ENCODE ZSTD,
+        date              date            ENCODE AZ64,
+        query             VARCHAR(2048)   ENCODE ZSTD,
+        country           VARCHAR(255)    ENCODE ZSTD,
+        device            VARCHAR(255)    ENCODE ZSTD,
+        page              VARCHAR(2047)   ENCODE ZSTD,
+        position          FLOAT           ENCODE ZSTD,
+        clicks            DECIMAL         ENCODE ZSTD,
+        ctr               FLOAT           ENCODE ZSTD,
+        impressions       DECIMAL         ENCODE ZSTD,
+        node_id           VARCHAR(255)    ENCODE ZSTD,
+        page_urlhost      VARCHAR(255)    ENCODE ZSTD,
+        title             VARCHAR(2047)   ENCODE ZSTD,
+        theme_id          VARCHAR(255)    ENCODE ZSTD,
+        subtheme_id       VARCHAR(255)    ENCODE ZSTD,
+        topic_id          VARCHAR(255)    ENCODE ZSTD,
+        subtopic_id       VARCHAR(255)    ENCODE ZSTD,
+        subsubtopic_id    VARCHAR(255)    ENCODE ZSTD,
+        theme             VARCHAR(2047)   ENCODE ZSTD,
+        subtheme          VARCHAR(2047)   ENCODE ZSTD,
+        topic             VARCHAR(2047)   ENCODE ZSTD,
+        subtopic          VARCHAR(2047)   ENCODE ZSTD,
+        subsubtopic       VARCHAR(2047)   ENCODE ZSTD)
+        COMPOUND SORTKEY (date,page_urlhost,theme,page,clicks);
 
-# ALTER TABLE cmslite.google_pdt OWNER TO microservice;
-# GRANT SELECT ON cmslite.google_pdt TO looker;
+ALTER TABLE cmslite.google_pdt OWNER TO microservice;
+GRANT SELECT ON cmslite.google_pdt TO looker;
 
-# INSERT INTO cmslite.google_pdt
-#       SELECT gs.*,
-#           COALESCE(node_id,'') AS node_id,
-#           SPLIT_PART(page, '/',3) as page_urlhost,
-#           title,
-#           theme_id, subtheme_id, topic_id, subtopic_id, subsubtopic_id, theme,
-#           subtheme, topic, subtopic, subsubtopic
-#       FROM google.googlesearch AS gs
-#       -- fix for misreporting of redirected front page URL in Google search
-#       LEFT JOIN cmslite.themes AS themes ON
-#         CASE WHEN page = 'https://www2.gov.bc.ca/'
-#             THEN 'https://www2.gov.bc.ca/gov/content/home'
-#             ELSE page
-#             END = themes.hr_url
-#         WHERE site NOT IN ('sc-domain:gov.bc.ca', 'sc-domain:engage.gov.bc.ca')
-#             OR site = 'sc-domain:gov.bc.ca' AND page_urlhost NOT IN (
-#                 'healthgateway.gov.bc.ca',
-#                 'engage.gov.bc.ca',
-#                 'feedback.engage.gov.bc.ca',
-#                 'www2.gov.bc.ca',
-#                 'www.engage.gov.bc.ca',
-#                 'curriculum.gov.bc.ca',
-#                 'studentsuccess.gov.bc.ca',
-#                 'news.gov.bc.ca',
-#                 'bcforhighschool.gov.bc.ca')
-#             OR site = 'sc-domain:engage.gov.bc.ca';
+INSERT INTO cmslite.google_pdt
+      SELECT gs.*,
+          COALESCE(node_id,'') AS node_id,
+          SPLIT_PART(page, '/',3) as page_urlhost,
+          title,
+          theme_id, subtheme_id, topic_id, subtopic_id, subsubtopic_id, theme,
+          subtheme, topic, subtopic, subsubtopic
+      FROM google.googlesearch AS gs
+      -- fix for misreporting of redirected front page URL in Google search
+      LEFT JOIN cmslite.themes AS themes ON
+        CASE WHEN page = 'https://www2.gov.bc.ca/'
+            THEN 'https://www2.gov.bc.ca/gov/content/home'
+            ELSE page
+            END = themes.hr_url
+        WHERE site NOT IN ('sc-domain:gov.bc.ca', 'sc-domain:engage.gov.bc.ca')
+            OR site = 'sc-domain:gov.bc.ca' AND page_urlhost NOT IN (
+                'healthgateway.gov.bc.ca',
+                'engage.gov.bc.ca',
+                'feedback.engage.gov.bc.ca',
+                'www2.gov.bc.ca',
+                'www.engage.gov.bc.ca',
+                'curriculum.gov.bc.ca',
+                'studentsuccess.gov.bc.ca',
+                'news.gov.bc.ca',
+                'bcforhighschool.gov.bc.ca')
+            OR site = 'sc-domain:engage.gov.bc.ca';
 
-# COMMIT;
-# """
+COMMIT;
+"""
 
-# # Execute the query and log the outcome
-# logger.debug(query)
-# with psycopg2.connect(conn_string) as conn:
-#     with conn.cursor() as curs:
-#         try:
-#             curs.execute(query)
-#         except psycopg2.Error:
-#             logger.exception("Google Search PDT loading failed")
-#             report_stats['pdt_build_succcess'] = True
-#             clean_exit(1,'Could not rebuild PDT in Redshift.')
-#         else:
-#             logger.debug("Google Search PDT loaded successfully")
-#             clean_exit(0,'Finished succesfully.')
+# Execute the query and log the outcome
+logger.debug(query)
+with psycopg2.connect(conn_string) as conn:
+    with conn.cursor() as curs:
+        try:
+            curs.execute(query)
+        except psycopg2.Error:
+            logger.exception("Google Search PDT loading failed")
+            report_stats['pdt_build_succcess'] = True
+            clean_exit(1,'Could not rebuild PDT in Redshift.')
+        else:
+            logger.debug("Google Search PDT loaded successfully")
+            clean_exit(0,'Finished succesfully.')
 
 report(report_stats)

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -239,7 +239,7 @@ def report(data):
     print(f'\nSites to process: {data["sites"]}')
     print(f'Successful API calls: {data["retrieved"]}')
     print(f'Failed API calls: {data["failed"]}\n')
-    print(f'Objects loaded to S3 and copied to RedShift:\n')
+    print(f'Objects loaded to S3 and copied to RedShift:')
 
     # Print all processed sites
     for item in data['processed']:
@@ -249,7 +249,7 @@ def report(data):
     if not data['failed_to_rs']:
         print(f'List of objects that failed to copy to Redshift: \n\nNone\n')
     else:
-        print(f'List of objects that failed to copy to Redshift:')
+        print(f'\nList of objects that failed to copy to Redshift:')
         for item in data['failed_to_rs']:
             print(f'\n{item}')
 

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -262,7 +262,7 @@ def report(data):
         print(f'\nList of objects that failed to copy to Redshift: \n\nNone\n')
     else:
         print(f'\nList of objects that failed to copy to Redshift:')
-        for item in data['failed_to_rs']:
+        for i, item in enumerate(data['failed_to_rs'], 1):
             print(f'\n{item}')
 
     # If nothing failed do to early exit, print None
@@ -270,7 +270,7 @@ def report(data):
         print(f'List of sites not processed due to early exit: \n\nNone\n')
     else:
         print(f'List of sites that were not processed due to early exit:')
-        for item in data['failed_api_call']:
+        for i, item in enumerate(data['failed_api_call']), 1:
             print(f'\n{item}')
     
     if report_stats['pdt_build_success']:

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -317,7 +317,6 @@ for site_item in config_sites:  # noqa: C901
     
     # add site_name to failed lists. Will be removed on success
     report_stats['failed_api_call'].append(site_name)
-    print(report_stats['failed_api_call'])  # Test
 
     # get the last loaded date.
     # may be None if this site has not previously been loaded into Redshift
@@ -440,7 +439,7 @@ for site_item in config_sites:  # noqa: C901
                         sleep(wait_time)
                     else:
                         # Remove site_name from failed list
-                        del report_stats['failed_api_call'][-1]
+                        report_stats['failed_api_call'].remove(site_name)
                         break
 
                 index = index + 1

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -368,6 +368,8 @@ for site_item in config_sites:  # noqa: C901
                         if retry == 11:
                             logger.error(("Failing with HTTP error after 10 "
                                           "retries with query time easening."))
+                            report_stats['failed'] += 1
+                            report_stats['failed_api_call'].append('PLACEHOLDER')  # Determine if I should rebuild filename in a new variable, or if moving site_fqdn and outfile up is feasible.
                             sys.exit()
                         wait_time = wait_time * 2
                         logger.warning(
@@ -376,6 +378,7 @@ for site_item in config_sites:  # noqa: C901
                         retry = retry + 1
                         sleep(wait_time)
                     else:
+                        report_stats['retrieved'] += 1
                         break
 
                 index = index + 1

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -622,6 +622,6 @@ with psycopg2.connect(conn_string) as conn:
         else:
             report_stats['pdt_build_success'] = True
             logger.debug("Google Search PDT loaded successfully")
-            clean_exit(0,'Finished succesfully.')
-
-report(report_stats)
+            report(report_stats)
+            clean_exit(0,'Finished successfully.')
+            

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -235,29 +235,25 @@ def report(data):
     # if no objects were processed; do not print a report
     if data['sites'] == 0:
         return
-    print('SUCCESS')
-    print(f'report {__file__}:')
+    print(f'{__file__} report:')
     print(f'\nSites to process: {data["sites"]}')
-    #print(f'Objects successfully processed: {data["processed"]}')
-    #print(f'Objects that failed to process: {data["failed"]}')
-    #print(f'Objects output to \'processed/good\': {data["good"]}')
-    #print(f'Objects output to \'processed/bad\': {data["bad"]}')
-    #print(f'Objects loaded to Redshift: {data["loaded"]}')
+    print(f'Successful API calls: {data["retrieved"]}')
+    print(f'Failed API calls: {data["failed"]}')
+    print(f'Objects loaded to S3 and copied to RedShift: {data["processed"]}')
+    print(f'List of objects that failed to copy to Redshift: {data["failed_to_rs"]}')
+    print(f'List of objects that were not processed due to early exit: {data["early_objects"]}')
 
 
 # Reporting variables. Accumulates as the the sites listed in google_search.json are looped over
 report_stats = {
-    'sites':0,  # Number of sites to loop through 
-    'processed':0,
+    'sites':0,  # Number of sites in google_search.json 
+    'retrieved':0,
     'failed':0,
-    'good': 0,
-    'bad': 0,
-    'loaded': 0,
-    'good_list':[],
-    'bad_list':[],
-    'incomplete_list':[]
+    'processed':[],  # Successfully called from the API, loaded to S3, and copied to Redshift
+    'failed_to_rs':[],  # Objects that failed to copy to Redshift
+    'failed_api_call':[]  # Objects not processed due to early exit
 }
-
+#
 report_stats['sites'] = len(config_sites)
 
 # each site in the config list of sites gets processed in this loop
@@ -548,5 +544,4 @@ for site_item in config_sites:  # noqa: C901
 #             logger.info("Google Search PDT loaded successfully")
 #             clean_exit(0,'Finished succesfully.')
 
-print('Number of Sites:', report_stats['sites'])  # Printing to validate aginst report(report_stats)
 report(report_stats)

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -427,7 +427,6 @@ for site_item in config_sites:  # noqa: C901
                                           "retries with query time easening."))
                             report_stats['failed_api'] += 1
                             report_stats['retrieved'] -= 1
-                            report_stats['failed_rs'] += 1
                             # Run report to output any stats avaiable
                             report(report_stats)
                             sys.exit()
@@ -519,6 +518,7 @@ for site_item in config_sites:  # noqa: C901
                         "%s to %s into %s. Object key %s.", site_name,
                         str(index), str(start_dt), str(end_dt),
                         config_dbtable, object_key.split('/')[-1])
+                    report_stats['failed_rs'] += 1
                     clean_exit(1,'Could not load to redshift.')
                 else:
                     report_stats['failed_to_rs'].remove(s3_file_path)

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -241,7 +241,7 @@ def report(data):
     print(f'Failed API calls: {data["failed"]}')
     print(f'Objects loaded to S3 and copied to RedShift: {data["processed"]}')
     print(f'List of objects that failed to copy to Redshift: {data["failed_to_rs"]}')
-    print(f'List of objects that were not processed due to early exit: {data["early_objects"]}')
+    print(f'List of objects that were not processed due to early exit: {data["failed_api_call"]}')
 
 
 # Reporting variables. Accumulates as the the sites listed in google_search.json are looped over

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -613,7 +613,7 @@ yvr_dt_pdt_start = (yvr_tz
 #             curs.execute(query)
 #         except psycopg2.Error:
 #             logger.exception("Google Search PDT loading failed")
-#             report_stats['pdt_build_succcess] = True
+#             report_stats['pdt_build_succcess'] = True
 #             clean_exit(1,'Could not rebuild PDT in Redshift.')
 #         else:
 #             logger.debug("Google Search PDT loaded successfully")

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -267,7 +267,7 @@ def report(data):
 
     # If nothing failed do to early exit, print None
     if not data['failed_api_call']:
-        print(f'List of objects that were not processed due to early exit: \n\nNone\n')
+        print(f'List of sites not processed due to early exit: \n\nNone\n')
     else:
         print(f'List of objects that were not processed due to early exit:/n')
         for item in data['failed_api_call']:
@@ -294,8 +294,6 @@ def report(data):
         f'ended at: {yvr_dt_end.strftime("%Y-%m-%d %H:%M:%S%z (%Z)")}, '
         f'elapsing: {yvr_dt_end - yvr_dt_start}.')
 
-
-
 # Reporting variables. Accumulates as the the sites lare looped over
 report_stats = {
     'sites':0,  # Number of sites in google_search.json 
@@ -307,7 +305,7 @@ report_stats = {
     'failed_api_call':[],  # Objects not processed due to early exit
     'pdt_build_success':False  # Will become 1 if successfull
 }
-#
+
 report_stats['sites'] = len(config_sites)
 report_stats['retrieved'] = len(config_sites)  # Will be subtracted from if a failure occurs
 
@@ -430,6 +428,8 @@ for site_item in config_sites:  # noqa: C901
                             report_stats['failed'] += 1
                             report_stats['retrieved'] -= 1
                             report_stats['failed_api_call'].append(current_file)
+                            # Run report to output any stats avaiable
+                            report(report_stats)
                             sys.exit()
                         wait_time = wait_time * 2
                         logger.warning(

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -272,13 +272,18 @@ def report(data):
         for item in data['failed_api_call']:
             print(f'\n{item}')
     
+    if report_stats['pdt_build_success']:
+        print('Google Search PDT loaded successfully')
+    else:
+        print("Google Search PDT load failed")
+
     # get times from system and convert to Americas/Vancouver for printing
     yvr_dt_end = (yvr_tz
         .normalize(datetime.now(local_tz)
         .astimezone(yvr_tz)))
 
     print(
-        '\nPDT build started at: '
+        'PDT build started at: '
         f'{yvr_dt_pdt_start.strftime("%Y-%m-%d %H:%M:%S%z (%Z)")}, '
         f'ended at: {yvr_dt_end.strftime("%Y-%m-%d %H:%M:%S%z (%Z)")}, '
         f'elapsing: {yvr_dt_end - yvr_dt_pdt_start}.')
@@ -290,14 +295,15 @@ def report(data):
 
 
 
-# Reporting variables. Accumulates as the the sites listed in google_search.json are looped over
+# Reporting variables. Accumulates as the the sites lare looped over
 report_stats = {
     'sites':0,  # Number of sites in google_search.json 
-    'retrieved':0,  # Starts as same values as sites. Minus 1 for each failed API call.
+    'retrieved':0,  # Successful API calls
     'failed':0,
-    'processed':[],  # Successfully called from the API, loaded to S3, and copied to Redshift
+    'processed':[],  # API call, load to S3, and copy to Redshift all OK
     'failed_to_rs':[],  # Objects that failed to copy to Redshift
-    'failed_api_call':[]  # Objects not processed due to early exit
+    'failed_api_call':[],  # Objects not processed due to early exit
+    'pdt_build_success':False  # Will become 1 if successfull
 }
 #
 report_stats['sites'] = len(config_sites)
@@ -602,9 +608,10 @@ yvr_dt_pdt_start = (yvr_tz
 #             curs.execute(query)
 #         except psycopg2.Error:
 #             logger.exception("Google Search PDT loading failed")
+#             report_stats['pdt_build_succcess] = True
 #             clean_exit(1,'Could not rebuild PDT in Redshift.')
 #         else:
-#             logger.info("Google Search PDT loaded successfully")
+#             logger.debug("Google Search PDT loaded successfully")
 #             clean_exit(0,'Finished succesfully.')
 
 report(report_stats)

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -471,7 +471,7 @@ for site_item in config_sites:  # noqa: C901
             continue
         
         if max_date_in_data < str(end_dt):
-            logger.warning('The date range in the request spanned %s - %s, '
+            logger.debug('The date range in the request spanned %s - %s, '
                            'but the max date in the data retrieved was: %s',
                            str(start_dt),str(end_dt),str(max_date_in_data))
 

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -319,7 +319,7 @@ for site_item in config_sites:  # noqa: C901
                 yield start_date + timedelta(_n)
 
         search_analytics_response = ''
-
+        
         # loops on each date from start date to the end date, inclusive
         # initializing date_in_range avoids pylint [undefined-loop-variable]
         date_in_range = ()
@@ -352,6 +352,10 @@ for site_item in config_sites:  # noqa: C901
                     "rowLimit": rowlimit,
                     "startRow": index * rowlimit}
 
+                # Set name of current file 
+                temp_fqdn = re.sub(r'^https?:\/\/', '', re.sub(r'\/$', '', site_name))
+                current_file = f"googlesearch-{temp_fqdn}-{start_dt}-{max_date_in_data}.csv"
+
                 # This query to the Google Search API may eventually yield an
                 # HTTP response code of 429, "Rate Limit Exceeded".
                 # The handling attempt below will increase the wait time on
@@ -369,7 +373,7 @@ for site_item in config_sites:  # noqa: C901
                             logger.error(("Failing with HTTP error after 10 "
                                           "retries with query time easening."))
                             report_stats['failed'] += 1
-                            report_stats['failed_api_call'].append('PLACEHOLDER')  # Determine if I should rebuild filename in a new variable, or if moving site_fqdn and outfile up is feasible.
+                            report_stats['failed_api_call'].append(current_file)
                             sys.exit()
                         wait_time = wait_time * 2
                         logger.warning(

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -438,8 +438,6 @@ for site_item in config_sites:  # noqa: C901
                         retry = retry + 1
                         sleep(wait_time)
                     else:
-                        # Remove site_name from failed list
-                        report_stats['failed_api_call'].remove(site_name)
                         break
 
                 index = index + 1
@@ -523,15 +521,19 @@ for site_item in config_sites:  # noqa: C901
                         config_dbtable, object_key.split('/')[-1])
                     clean_exit(1,'Could not load to redshift.')
                 else:
-                    del report_stats['failed_to_rs'][-1]
                     report_stats['processed'].append(s3_file_path)
                     logger.debug(
                         "SUCCESS loading %s (%s index) over date range "
                         "%s to %s into %s. Object key %s.", site_name,
                         str(index), str(start_dt), str(end_dt),
                         config_dbtable, object_key.split('/')[-1])
+
         # set last_loaded_date to end_dt to iterate through the next month
         last_loaded_date = end_dt
+
+    # Remove site_name from failed lists
+    report_stats['failed_api_call'].remove(site_name)
+    report_stats['failed_to_rs'].remove(site_name)
 
 # Count all failed loads to RedShift        
 report_stats['failed_rs'] = len(report_stats['failed_to_rs'])

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -317,7 +317,7 @@ for site_item in config_sites:  # noqa: C901
     
     # add site_name to failed lists. Will be removed on success
     report_stats['failed_api_call'].append(site_name)
-    report_stats['failed_to_rs'].append(site_name)
+    print(report_stats['failed_api_call'])  # Test
 
     # get the last loaded date.
     # may be None if this site has not previously been loaded into Redshift
@@ -440,7 +440,7 @@ for site_item in config_sites:  # noqa: C901
                         sleep(wait_time)
                     else:
                         # Remove site_name from failed list
-                        report_stats['failed_api_call'].remove(site_name)
+                        del report_stats['failed_api_call'][-1]
                         break
 
                 index = index + 1
@@ -496,6 +496,7 @@ for site_item in config_sites:  # noqa: C901
 
         # S3 file path for report_stats
         s3_file_path = f's3://{config_bucket}/{object_key}'
+        report_stats['failed_to_rs'].append(s3_file_path)
 
         # Prepare the Redshift COPY command.
         logquery = (
@@ -523,7 +524,7 @@ for site_item in config_sites:  # noqa: C901
                         config_dbtable, object_key.split('/')[-1])
                     clean_exit(1,'Could not load to redshift.')
                 else:
-                    report_stats['failed_to_rs'].remove(s3_file_path)
+                    del report_stats['failed_to_rs'][-1]
                     report_stats['processed'].append(s3_file_path)
                     logger.debug(
                         "SUCCESS loading %s (%s index) over date range "

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -438,82 +438,82 @@ for site_item in config_sites:  # noqa: C901
         last_loaded_date = end_dt
 
 
-# This query will INSERT data that is the result of a JOIN into
-# cmslite.google_pdt, a persistent dereived table which facilitating the LookML
-query = """
--- perform this as a transaction.
--- Either the whole query completes, or it leaves the old table intact
-BEGIN;
-DROP TABLE IF EXISTS cmslite.google_pdt;
+# # This query will INSERT data that is the result of a JOIN into
+# # cmslite.google_pdt, a persistent dereived table which facilitating the LookML
+# query = """
+# -- perform this as a transaction.
+# -- Either the whole query completes, or it leaves the old table intact
+# BEGIN;
+# DROP TABLE IF EXISTS cmslite.google_pdt;
 
-CREATE TABLE IF NOT EXISTS cmslite.google_pdt (
-        site              VARCHAR(255)    ENCODE ZSTD,
-        date              date            ENCODE AZ64,
-        query             VARCHAR(2048)   ENCODE ZSTD,
-        country           VARCHAR(255)    ENCODE ZSTD,
-        device            VARCHAR(255)    ENCODE ZSTD,
-        page              VARCHAR(2047)   ENCODE ZSTD,
-        position          FLOAT           ENCODE ZSTD,
-        clicks            DECIMAL         ENCODE ZSTD,
-        ctr               FLOAT           ENCODE ZSTD,
-        impressions       DECIMAL         ENCODE ZSTD,
-        node_id           VARCHAR(255)    ENCODE ZSTD,
-        page_urlhost      VARCHAR(255)    ENCODE ZSTD,
-        title             VARCHAR(2047)   ENCODE ZSTD,
-        theme_id          VARCHAR(255)    ENCODE ZSTD,
-        subtheme_id       VARCHAR(255)    ENCODE ZSTD,
-        topic_id          VARCHAR(255)    ENCODE ZSTD,
-        subtopic_id       VARCHAR(255)    ENCODE ZSTD,
-        subsubtopic_id    VARCHAR(255)    ENCODE ZSTD,
-        theme             VARCHAR(2047)   ENCODE ZSTD,
-        subtheme          VARCHAR(2047)   ENCODE ZSTD,
-        topic             VARCHAR(2047)   ENCODE ZSTD,
-        subtopic          VARCHAR(2047)   ENCODE ZSTD,
-        subsubtopic       VARCHAR(2047)   ENCODE ZSTD)
-        COMPOUND SORTKEY (date,page_urlhost,theme,page,clicks);
+# CREATE TABLE IF NOT EXISTS cmslite.google_pdt (
+#         site              VARCHAR(255)    ENCODE ZSTD,
+#         date              date            ENCODE AZ64,
+#         query             VARCHAR(2048)   ENCODE ZSTD,
+#         country           VARCHAR(255)    ENCODE ZSTD,
+#         device            VARCHAR(255)    ENCODE ZSTD,
+#         page              VARCHAR(2047)   ENCODE ZSTD,
+#         position          FLOAT           ENCODE ZSTD,
+#         clicks            DECIMAL         ENCODE ZSTD,
+#         ctr               FLOAT           ENCODE ZSTD,
+#         impressions       DECIMAL         ENCODE ZSTD,
+#         node_id           VARCHAR(255)    ENCODE ZSTD,
+#         page_urlhost      VARCHAR(255)    ENCODE ZSTD,
+#         title             VARCHAR(2047)   ENCODE ZSTD,
+#         theme_id          VARCHAR(255)    ENCODE ZSTD,
+#         subtheme_id       VARCHAR(255)    ENCODE ZSTD,
+#         topic_id          VARCHAR(255)    ENCODE ZSTD,
+#         subtopic_id       VARCHAR(255)    ENCODE ZSTD,
+#         subsubtopic_id    VARCHAR(255)    ENCODE ZSTD,
+#         theme             VARCHAR(2047)   ENCODE ZSTD,
+#         subtheme          VARCHAR(2047)   ENCODE ZSTD,
+#         topic             VARCHAR(2047)   ENCODE ZSTD,
+#         subtopic          VARCHAR(2047)   ENCODE ZSTD,
+#         subsubtopic       VARCHAR(2047)   ENCODE ZSTD)
+#         COMPOUND SORTKEY (date,page_urlhost,theme,page,clicks);
 
-ALTER TABLE cmslite.google_pdt OWNER TO microservice;
-GRANT SELECT ON cmslite.google_pdt TO looker;
+# ALTER TABLE cmslite.google_pdt OWNER TO microservice;
+# GRANT SELECT ON cmslite.google_pdt TO looker;
 
-INSERT INTO cmslite.google_pdt
-      SELECT gs.*,
-          COALESCE(node_id,'') AS node_id,
-          SPLIT_PART(page, '/',3) as page_urlhost,
-          title,
-          theme_id, subtheme_id, topic_id, subtopic_id, subsubtopic_id, theme,
-          subtheme, topic, subtopic, subsubtopic
-      FROM google.googlesearch AS gs
-      -- fix for misreporting of redirected front page URL in Google search
-      LEFT JOIN cmslite.themes AS themes ON
-        CASE WHEN page = 'https://www2.gov.bc.ca/'
-            THEN 'https://www2.gov.bc.ca/gov/content/home'
-            ELSE page
-            END = themes.hr_url
-        WHERE site NOT IN ('sc-domain:gov.bc.ca', 'sc-domain:engage.gov.bc.ca')
-            OR site = 'sc-domain:gov.bc.ca' AND page_urlhost NOT IN (
-                'healthgateway.gov.bc.ca',
-                'engage.gov.bc.ca',
-                'feedback.engage.gov.bc.ca',
-                'www2.gov.bc.ca',
-                'www.engage.gov.bc.ca',
-                'curriculum.gov.bc.ca',
-                'studentsuccess.gov.bc.ca',
-                'news.gov.bc.ca',
-                'bcforhighschool.gov.bc.ca')
-            OR site = 'sc-domain:engage.gov.bc.ca';
+# INSERT INTO cmslite.google_pdt
+#       SELECT gs.*,
+#           COALESCE(node_id,'') AS node_id,
+#           SPLIT_PART(page, '/',3) as page_urlhost,
+#           title,
+#           theme_id, subtheme_id, topic_id, subtopic_id, subsubtopic_id, theme,
+#           subtheme, topic, subtopic, subsubtopic
+#       FROM google.googlesearch AS gs
+#       -- fix for misreporting of redirected front page URL in Google search
+#       LEFT JOIN cmslite.themes AS themes ON
+#         CASE WHEN page = 'https://www2.gov.bc.ca/'
+#             THEN 'https://www2.gov.bc.ca/gov/content/home'
+#             ELSE page
+#             END = themes.hr_url
+#         WHERE site NOT IN ('sc-domain:gov.bc.ca', 'sc-domain:engage.gov.bc.ca')
+#             OR site = 'sc-domain:gov.bc.ca' AND page_urlhost NOT IN (
+#                 'healthgateway.gov.bc.ca',
+#                 'engage.gov.bc.ca',
+#                 'feedback.engage.gov.bc.ca',
+#                 'www2.gov.bc.ca',
+#                 'www.engage.gov.bc.ca',
+#                 'curriculum.gov.bc.ca',
+#                 'studentsuccess.gov.bc.ca',
+#                 'news.gov.bc.ca',
+#                 'bcforhighschool.gov.bc.ca')
+#             OR site = 'sc-domain:engage.gov.bc.ca';
 
-COMMIT;
-"""
+# COMMIT;
+# """
 
-# Execute the query and log the outcome
-logger.debug(query)
-with psycopg2.connect(conn_string) as conn:
-    with conn.cursor() as curs:
-        try:
-            curs.execute(query)
-        except psycopg2.Error:
-            logger.exception("Google Search PDT loading failed")
-            clean_exit(1,'Could not rebuild PDT in Redshift.')
-        else:
-            logger.info("Google Search PDT loaded successfully")
-            clean_exit(0,'Finished succesfully.')
+# # Execute the query and log the outcome
+# logger.debug(query)
+# with psycopg2.connect(conn_string) as conn:
+#     with conn.cursor() as curs:
+#         try:
+#             curs.execute(query)
+#         except psycopg2.Error:
+#             logger.exception("Google Search PDT loading failed")
+#             clean_exit(1,'Could not rebuild PDT in Redshift.')
+#         else:
+#             logger.info("Google Search PDT loaded successfully")
+#             clean_exit(0,'Finished succesfully.')

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -235,8 +235,9 @@ def report(data):
     # if no objects were processed; do not print a report
     if data['sites'] == 0:
         return
+    print('SUCCESS')
     print(f'report {__file__}:')
-    #print(f'\nSites to process: {data["objects"]}')
+    print(f'\nSites to process: {data["sites"]}')
     #print(f'Objects successfully processed: {data["processed"]}')
     #print(f'Objects that failed to process: {data["failed"]}')
     #print(f'Objects output to \'processed/good\': {data["good"]}')
@@ -547,4 +548,5 @@ for site_item in config_sites:  # noqa: C901
 #             logger.info("Google Search PDT loaded successfully")
 #             clean_exit(0,'Finished succesfully.')
 
+print('Number of Sites:', report_stats['sites'])  # Printing to validate aginst report(report_stats)
 report(report_stats)

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -428,7 +428,7 @@ for site_item in config_sites:  # noqa: C901
                                           "retries with query time easening."))
                             report_stats['failed_api'] += 1
                             report_stats['retrieved'] -= 1
-                            report_stats['failed_rs'] -= 1
+                            report_stats['failed_rs'] += 1
                             report_stats['failed_api_call'].append(current_file)
                             # Run report to output any stats avaiable
                             report(report_stats)

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -309,6 +309,7 @@ report_stats = {
 
 report_stats['sites'] = len(config_sites)
 report_stats['retrieved'] = len(config_sites)  # Minus 1 if failure occurs
+report_stats['failed_api_call'] = config_sites.copy()
 
 # each site in the config list of sites gets processed in this loop
 for site_item in config_sites:  # noqa: C901
@@ -406,10 +407,6 @@ for site_item in config_sites:  # noqa: C901
                     "rowLimit": rowlimit,
                     "startRow": index * rowlimit}
 
-                # Set name of current file 
-                temp_fqdn = re.sub(r'^https?:\/\/', '', re.sub(r'\/$', '', site_name))
-                current_file = f"googlesearch-{temp_fqdn}-{start_dt}-{max_date_in_data}.csv"
-
                 # This query to the Google Search API may eventually yield an
                 # HTTP response code of 429, "Rate Limit Exceeded".
                 # The handling attempt below will increase the wait time on
@@ -429,7 +426,6 @@ for site_item in config_sites:  # noqa: C901
                             report_stats['failed_api'] += 1
                             report_stats['retrieved'] -= 1
                             report_stats['failed_rs'] += 1
-                            report_stats['failed_api_call'].append(current_file)
                             # Run report to output any stats avaiable
                             report(report_stats)
                             sys.exit()
@@ -440,6 +436,8 @@ for site_item in config_sites:  # noqa: C901
                         retry = retry + 1
                         sleep(wait_time)
                     else:
+                        # Remove site_name from failed list
+                        report_stats['failed_api_call'].remove(site_name)
                         break
 
                 index = index + 1

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -309,13 +309,15 @@ report_stats = {
 
 report_stats['sites'] = len(config_sites)
 report_stats['retrieved'] = len(config_sites)  # Minus 1 if failure occurs
-report_stats['failed_api_call'] = config_sites.copy()
-report_stats['failed_to_rs'] = config_sites.copy()
 
 # each site in the config list of sites gets processed in this loop
 for site_item in config_sites:  # noqa: C901
     # read the config for the site name and default start date if specified
     site_name = site_item["name"]
+    
+    # add site_name to failed lists. Will be removed on success
+    report_stats['failed_api_call'].append(site_name)
+    report_stats['failed_to_rs'].append(site_name)
 
     # get the last loaded date.
     # may be None if this site has not previously been loaded into Redshift

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -486,7 +486,7 @@ for site_item in config_sites:  # noqa: C901
                     clean_exit(1,'Could not load to redshift.')
                 else:
                     report_stats['processed'].append(s3_file_path)
-                    logger.info(
+                    logger.debug(
                         "SUCCESS loading %s (%s index) over date range "
                         "%s to %s into %s. Object key %s.", site_name,
                         str(index), str(start_dt), str(end_dt),

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -229,6 +229,21 @@ conn_string = (
     f"user='{pguser}' "
     f"password={pgpass}")
 
+# Will run at end of script to print out accumulated report_stats
+def report(data):
+    '''reports out the data from the main program loop'''
+    # if no objects were processed; do not print a report
+    if data['sites'] == 0:
+        return
+    print(f'report {__file__}:')
+    #print(f'\nSites to process: {data["objects"]}')
+    #print(f'Objects successfully processed: {data["processed"]}')
+    #print(f'Objects that failed to process: {data["failed"]}')
+    #print(f'Objects output to \'processed/good\': {data["good"]}')
+    #print(f'Objects output to \'processed/bad\': {data["bad"]}')
+    #print(f'Objects loaded to Redshift: {data["loaded"]}')
+
+
 # Reporting variables. Accumulates as the the sites listed in google_search.json are looped over
 report_stats = {
     'sites':0,  # Number of sites to loop through 

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -310,14 +310,14 @@ report_stats = {
 report_stats['sites'] = len(config_sites)
 report_stats['retrieved'] = len(config_sites)  # Minus 1 if failure occurs
 
+for site_item in config_sites:
+    report_stats['failed_api_call'].append(site_item['name'])
+
 # each site in the config list of sites gets processed in this loop
 for site_item in config_sites:  # noqa: C901
     # read the config for the site name and default start date if specified
     site_name = site_item["name"]
     
-    # add site_name to failed lists. Will be removed on success
-    report_stats['failed_api_call'].append(site_name)
-
     # get the last loaded date.
     # may be None if this site has not previously been loaded into Redshift
     last_loaded_date = last_loaded(site_name)

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -312,8 +312,7 @@ report_stats['retrieved'] = len(config_sites)  # Minus 1 if failure occurs
 
 for site_item in config_sites:
     report_stats['failed_api_call'].append(site_item['name'])
-    report_stats['failed_to_rs'].append(site_item['name'])
-
+    
 # each site in the config list of sites gets processed in this loop
 for site_item in config_sites:  # noqa: C901
     # read the config for the site name and default start date if specified
@@ -522,6 +521,7 @@ for site_item in config_sites:  # noqa: C901
                         config_dbtable, object_key.split('/')[-1])
                     clean_exit(1,'Could not load to redshift.')
                 else:
+                    report_stats['failed_to_rs'].remove(s3_file_path)
                     report_stats['processed'].append(s3_file_path)
                     logger.debug(
                         "SUCCESS loading %s (%s index) over date range "
@@ -534,7 +534,6 @@ for site_item in config_sites:  # noqa: C901
 
     # Remove site_name from failed lists
     report_stats['failed_api_call'].remove(site_name)
-    report_stats['failed_to_rs'].remove(site_name)
 
 # Count all failed loads to RedShift        
 report_stats['failed_rs'] = len(report_stats['failed_to_rs'])

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -254,8 +254,8 @@ def report(data):
     print(f'Objects loaded to S3 and copied to RedShift:')
 
     # Print all processed sites
-    for item in data['processed']:
-        print(f'\n{item}')
+    for i, site in enumerate(data['processed'], 1):
+        print(f"\n{i}: {site}")
 
     # If nothing failed to copy to RedShift, print None
     if not data['failed_to_rs']:
@@ -274,9 +274,9 @@ def report(data):
             print(f'\n{item}')
     
     if report_stats['pdt_build_success']:
-        print('Google Search PDT loaded successfully\n')
+        print('\nGoogle Search PDT loaded successfully\n')
     else:
-        print('Google Search PDT load failed\n')
+        print('\nGoogle Search PDT load failed\n')
 
     # get times from system and convert to Americas/Vancouver for printing
     yvr_dt_end = (yvr_tz
@@ -304,11 +304,11 @@ report_stats = {
     'processed':[],  # API call, load to S3, and copy to Redshift all OK
     'failed_to_rs':[],  # Objects that failed to copy to Redshift
     'failed_api_call':[],  # Objects not processed due to early exit
-    'pdt_build_success':False  # Will become 1 if successfull
+    'pdt_build_success':False  # True if successfull
 }
 
 report_stats['sites'] = len(config_sites)
-report_stats['retrieved'] = len(config_sites)  # Will be subtracted from if a failure occurs
+report_stats['retrieved'] = len(config_sites)  # Minus 1 if failure occurs
 
 # each site in the config list of sites gets processed in this loop
 for site_item in config_sites:  # noqa: C901
@@ -316,7 +316,7 @@ for site_item in config_sites:  # noqa: C901
     site_name = site_item["name"]
 
     # get the last loaded date.
-    # may be None if this site has not previously been loaded into Redshift)
+    # may be None if this site has not previously been loaded into Redshift
     last_loaded_date = last_loaded(site_name)
 
     # if the last load is 2 days old, there will be no new data in Google

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -263,15 +263,15 @@ def report(data):
     else:
         print(f'\nList of objects that failed to copy to Redshift:')
         for i, item in enumerate(data['failed_to_rs'], 1):
-            print(f'\n{item}')
+            print(f'\n{i}: {item}')
 
     # If nothing failed do to early exit, print None
     if not data['failed_api_call']:
         print(f'List of sites not processed due to early exit: \n\nNone\n')
     else:
         print(f'List of sites that were not processed due to early exit:')
-        for i, item in enumerate(data['failed_api_call']), 1:
-            print(f'\n{item}')
+        for i, site in enumerate(data['failed_api_call']), 1:
+            print(f'\n{i}: {site}')
     
     if report_stats['pdt_build_success']:
         print('\nGoogle Search PDT loaded successfully\n')

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -249,7 +249,8 @@ def report(data):
     print(f'{__file__} report:')
     print(f'\nSites to process: {data["sites"]}')
     print(f'Successful API calls: {data["retrieved"]}')
-    print(f'Failed API calls: {data["failed"]}\n')
+    print(f'Failed API calls: {data["failed"]}')
+    print(f'Failed loads to RedShift: {data["failed_rs"]}\n')
     print(f'Objects loaded to S3 and copied to RedShift:')
 
     # Print all processed sites
@@ -258,7 +259,7 @@ def report(data):
 
     # If nothing failed to copy to RedShift, print None
     if not data['failed_to_rs']:
-        print(f'List of objects that failed to copy to Redshift: \n\nNone\n')
+        print(f'\nList of objects that failed to copy to Redshift: \n\nNone\n')
     else:
         print(f'\nList of objects that failed to copy to Redshift:')
         for item in data['failed_to_rs']:
@@ -273,9 +274,9 @@ def report(data):
             print(f'\n{item}')
     
     if report_stats['pdt_build_success']:
-        print('Google Search PDT loaded successfully')
+        print('Google Search PDT loaded successfully\n')
     else:
-        print("Google Search PDT load failed")
+        print('Google Search PDT load failed\n')
 
     # get times from system and convert to Americas/Vancouver for printing
     yvr_dt_end = (yvr_tz
@@ -300,6 +301,7 @@ report_stats = {
     'sites':0,  # Number of sites in google_search.json 
     'retrieved':0,  # Successful API calls
     'failed':0,
+    'failed_rs':0,
     'processed':[],  # API call, load to S3, and copy to Redshift all OK
     'failed_to_rs':[],  # Objects that failed to copy to Redshift
     'failed_api_call':[],  # Objects not processed due to early exit
@@ -527,6 +529,9 @@ for site_item in config_sites:  # noqa: C901
                         config_dbtable, object_key.split('/')[-1])
         # set last_loaded_date to end_dt to iterate through the next month
         last_loaded_date = end_dt
+
+# Count all failed loads to RedShift        
+report_stats['failed_rs'] = len(report_stats['failed_to_rs'])
 
 # Get PDT build start time
 yvr_dt_pdt_start = (yvr_tz

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -240,15 +240,14 @@ def report(data):
     print(f'Successful API calls: {data["retrieved"]}')
     print(f'Failed API calls: {data["failed"]}')
     print(f'Objects loaded to S3 and copied to RedShift: {data["processed"]}')
-    if not data['processed']:
-        print(f'List of objects that failed to copy to Redshift:')
-        print('None')
+
+    if not data['failed_to_rs']:
+        print(f'List of objects that failed to copy to Redshift: None')
     else:
         print(f'List of objects that failed to copy to Redshift: {data["failed_to_rs"]}')
 
-    if not data['failed_to_rs']:
-        print(f'List of objects that were not processed due to early exit:')
-        print('None')
+    if not data['failed_api_call']:
+        print(f'List of objects that were not processed due to early exit: None')
     else:
         print(f'List of objects that were not processed due to early exit: {data["failed_api_call"]}')
 

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -239,17 +239,27 @@ def report(data):
     print(f'\nSites to process: {data["sites"]}')
     print(f'Successful API calls: {data["retrieved"]}')
     print(f'Failed API calls: {data["failed"]}')
-    print(f'Objects loaded to S3 and copied to RedShift: {data["processed"]}')
+    print(f'Objects loaded to S3 and copied to RedShift:')
 
+    # Print all processed sites
+    for item in data['processed']:
+        print(item)
+
+    # If nothing failed to copy to RedShift, print None
     if not data['failed_to_rs']:
-        print(f'List of objects that failed to copy to Redshift: None')
+        print(f'List of objects that failed to copy to Redshift: \n\nNone\n')
     else:
-        print(f'List of objects that failed to copy to Redshift: {data["failed_to_rs"]}')
+        print(f'List of objects that failed to copy to Redshift:')
+        for item in data['failed_to_rs']:
+            print(item)
 
+    # If nothing failed do to early exit, print None
     if not data['failed_api_call']:
-        print(f'List of objects that were not processed due to early exit: None')
+        print(f'List of objects that were not processed due to early exit: \n\nNone\n')
     else:
-        print(f'List of objects that were not processed due to early exit: {data["failed_api_call"]}')
+        print(f'List of objects that were not processed due to early exit:/n')
+        for item in data['failed_api_call']:
+            print(item)
 
 
 # Reporting variables. Accumulates as the the sites listed in google_search.json are looped over

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -310,6 +310,7 @@ report_stats = {
 report_stats['sites'] = len(config_sites)
 report_stats['retrieved'] = len(config_sites)  # Minus 1 if failure occurs
 report_stats['failed_api_call'] = config_sites.copy()
+report_stats['failed_to_rs'] = config_sites.copy()
 
 # each site in the config list of sites gets processed in this loop
 for site_item in config_sites:  # noqa: C901
@@ -513,7 +514,6 @@ for site_item in config_sites:  # noqa: C901
                     curs.execute(query)
                 # if the DB call fails, print error and place file in /bad
                 except psycopg2.Error:
-                    report_stats['failed_to_rs'].append(s3_file_path)
                     logger.exception(
                         "FAILURE loading %s (%s index) over date range "
                         "%s to %s into %s. Object key %s.", site_name,
@@ -521,6 +521,7 @@ for site_item in config_sites:  # noqa: C901
                         config_dbtable, object_key.split('/')[-1])
                     clean_exit(1,'Could not load to redshift.')
                 else:
+                    report_stats['failed_to_rs'].remove(s3_file_path)
                     report_stats['processed'].append(s3_file_path)
                     logger.debug(
                         "SUCCESS loading %s (%s index) over date range "

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -546,3 +546,5 @@ for site_item in config_sites:  # noqa: C901
 #         else:
 #             logger.info("Google Search PDT loaded successfully")
 #             clean_exit(0,'Finished succesfully.')
+
+report(report_stats)

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -75,7 +75,6 @@ from googleapiclient.errors import HttpError as GoogleHttpError
 import psycopg2  # For Amazon Redshift IO
 import lib.logs as log
 
-
 # Ctrl+C
 def signal_handler(sig, frame):
     '''Ctrl+C signal handler'''
@@ -229,6 +228,21 @@ conn_string = (
     f"port='{port}' "
     f"user='{pguser}' "
     f"password={pgpass}")
+
+# Reporting variables. Accumulates as the the sites listed in google_search.json are looped over
+report_stats = {
+    'sites':0,  # Number of sites to loop through 
+    'processed':0,
+    'failed':0,
+    'good': 0,
+    'bad': 0,
+    'loaded': 0,
+    'good_list':[],
+    'bad_list':[],
+    'incomplete_list':[]
+}
+
+report_stats['sites'] = len(config_sites)
 
 # each site in the config list of sites gets processed in this loop
 for site_item in config_sites:  # noqa: C901

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -238,12 +238,12 @@ def report(data):
     print(f'{__file__} report:')
     print(f'\nSites to process: {data["sites"]}')
     print(f'Successful API calls: {data["retrieved"]}')
-    print(f'Failed API calls: {data["failed"]}')
-    print(f'Objects loaded to S3 and copied to RedShift:')
+    print(f'Failed API calls: {data["failed"]}\n')
+    print(f'Objects loaded to S3 and copied to RedShift:\n')
 
     # Print all processed sites
     for item in data['processed']:
-        print(item)
+        print(f'\n{item}')
 
     # If nothing failed to copy to RedShift, print None
     if not data['failed_to_rs']:
@@ -251,7 +251,7 @@ def report(data):
     else:
         print(f'List of objects that failed to copy to Redshift:')
         for item in data['failed_to_rs']:
-            print(item)
+            print(f'\n{item}')
 
     # If nothing failed do to early exit, print None
     if not data['failed_api_call']:
@@ -259,7 +259,7 @@ def report(data):
     else:
         print(f'List of objects that were not processed due to early exit:/n')
         for item in data['failed_api_call']:
-            print(item)
+            print(f'\n{item}')
 
 
 # Reporting variables. Accumulates as the the sites listed in google_search.json are looped over

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -312,6 +312,7 @@ report_stats['retrieved'] = len(config_sites)  # Minus 1 if failure occurs
 
 for site_item in config_sites:
     report_stats['failed_api_call'].append(site_item['name'])
+    report_stats['failed_to_rs'].append(site_item['name'])
 
 # each site in the config list of sites gets processed in this loop
 for site_item in config_sites:  # noqa: C901

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -85,8 +85,6 @@ yvr_tz = timezone('America/Vancouver')
 yvr_dt_start = (yvr_tz
     .normalize(datetime.now(local_tz)
     .astimezone(yvr_tz)))
-# Set again at PDT build start time
-yvr_dt_pdt_start = ()
 
 # Ctrl+C
 def signal_handler(sig, frame):
@@ -285,11 +283,12 @@ def report(data):
         .normalize(datetime.now(local_tz)
         .astimezone(yvr_tz)))
 
-    print(
-        'PDT build started at: '
-        f'{yvr_dt_pdt_start.strftime("%Y-%m-%d %H:%M:%S%z (%Z)")}, '
-        f'ended at: {yvr_dt_end.strftime("%Y-%m-%d %H:%M:%S%z (%Z)")}, '
-        f'elapsing: {yvr_dt_end - yvr_dt_pdt_start}.')
+    if report_stats['pdt_build_success']:
+        print(
+            'PDT build started at: '
+            f'{yvr_dt_pdt_start.strftime("%Y-%m-%d %H:%M:%S%z (%Z)")}, '
+            f'ended at: {yvr_dt_end.strftime("%Y-%m-%d %H:%M:%S%z (%Z)")}, '
+            f'elapsing: {yvr_dt_end - yvr_dt_pdt_start}.')
     print(
         '\nMicroservice started at: '
         f'{yvr_dt_start.strftime("%Y-%m-%d %H:%M:%S%z (%Z)")}, '

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -618,10 +618,10 @@ with psycopg2.connect(conn_string) as conn:
             curs.execute(query)
         except psycopg2.Error:
             logger.exception("Google Search PDT loading failed")
+            report(report_stats)
             clean_exit(1,'Could not rebuild PDT in Redshift.')
         else:
             report_stats['pdt_build_success'] = True
             logger.debug("Google Search PDT loaded successfully")
             report(report_stats)
             clean_exit(0,'Finished successfully.')
-            

--- a/microservices/google-api/google_search.py
+++ b/microservices/google-api/google_search.py
@@ -249,7 +249,7 @@ def report(data):
     print(f'{__file__} report:')
     print(f'\nSites to process: {data["sites"]}')
     print(f'Successful API calls: {data["retrieved"]}')
-    print(f'Failed API calls: {data["failed"]}')
+    print(f'Failed API calls: {data["failed_api"]}')
     print(f'Failed loads to RedShift: {data["failed_rs"]}\n')
     print(f'Objects loaded to S3 and copied to RedShift:')
 
@@ -269,7 +269,7 @@ def report(data):
     if not data['failed_api_call']:
         print(f'List of sites not processed due to early exit: \n\nNone\n')
     else:
-        print(f'List of objects that were not processed due to early exit:/n')
+        print(f'List of sites that were not processed due to early exit:')
         for item in data['failed_api_call']:
             print(f'\n{item}')
     
@@ -299,7 +299,7 @@ def report(data):
 report_stats = {
     'sites':0,  # Number of sites in google_search.json 
     'retrieved':0,  # Successful API calls
-    'failed':0,
+    'failed_api':0,
     'failed_rs':0,
     'processed':[],  # API call, load to S3, and copy to Redshift all OK
     'failed_to_rs':[],  # Objects that failed to copy to Redshift
@@ -426,8 +426,9 @@ for site_item in config_sites:  # noqa: C901
                         if retry == 11:
                             logger.error(("Failing with HTTP error after 10 "
                                           "retries with query time easening."))
-                            report_stats['failed'] += 1
+                            report_stats['failed_api'] += 1
                             report_stats['retrieved'] -= 1
+                            report_stats['failed_rs'] -= 1
                             report_stats['failed_api_call'].append(current_file)
                             # Run report to output any stats avaiable
                             report(report_stats)


### PR DESCRIPTION
This pull request implements a better summary of the outcomes of running the microservice. It improves the existing INFO level log reporting, which can be difficult to decipher. 

The improvements are built into a function that reports out on several events within the script. These event are tracked while the script runs:

- The number of sites (API Calls) that will be made on this run
- How many of those calls were successful and how many failed
- The names of the sites that failed during the API call
- How many S3 objects failed to load into RedShift
- The S3 file paths of the objects, derived from the API calls, which failed to load into RedShift
- Whether the PDT Build failed or succeeded
- The scripts elapsed time and the PDT builds elapsed time.

The pytz and tzlocal have been added to the Pipfile