### PR TITLE
Fix gdx_analytics.restored_atomic_ca_bc_gov DDL

### DIFF
--- a/maintenance/s3-archive-restore/00-create-base-table.sql
+++ b/maintenance/s3-archive-restore/00-create-base-table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS gdx_analytics.restored_atomic_ca_bc_gov (
-    root_tstamp         TIMESTAMPTZ     ENCODE RAW,
+    root_tstamp         TIMESTAMP       ENCODE RAW,
     page_view_id        VARCHAR(36)     ENCODE ZSTD,
     root_id             CHAR(36)        ENCODE LZO,
     page_urlhost        VARCHAR(255)    ENCODE ZSTD,


### PR DESCRIPTION
`root_tstamp` is now a `TIMESTAMP` not a `TIMESTAMPTZ`.

To confirm, you can run:
```sql
select * from admin.v_generate_tbl_ddl where schemaname ='gdx_analytics' and tablename='restored_atomic_ca_bc_gov';
```
it returns:
```
CREATE TABLE IF NOT EXISTS gdx_analytics.restored_atomic_ca_bc_gov
(
        root_tstamp TIMESTAMP WITHOUT TIME ZONE   ENCODE RAW
        ,page_view_id VARCHAR(36)   ENCODE zstd
        ,root_id CHAR(36) NOT NULL  ENCODE lzo
        ,page_urlhost VARCHAR(255)   ENCODE zstd
        ,page_url VARCHAR(4096)   ENCODE zstd
        ,domain_sessionid CHAR(128)   ENCODE zstd
        ,PRIMARY KEY (root_id)
)
DISTSTYLE KEY
 DISTKEY (root_id)
 SORTKEY (
        root_tstamp
        )
;
```