### PR TITLE
GDXDSD-8490 - Resolve idna Dependabot alert for measure_tile_performance

### DIFF
--- a/maintenance/measure_tile_performance/Pipfile.lock
+++ b/maintenance/measure_tile_performance/Pipfile.lock
@@ -185,11 +185,12 @@
         },
         "idna": {
             "hashes": [
-                "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242",
-                "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3"
+                "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8",
+                "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==3.13"
+            "version": "==3.15"
         },
         "looker-sdk": {
             "hashes": [


### PR DESCRIPTION
Testing was completed from dev folder:

/home/microservice/branch/GDXDSD-8490-measure-tile-performance-idna/maintenance/measure_tile_performance

- Created a fresh Pipenv using the committed Pipfile.lock
- Confirmed Python 3.9.25
- Confirmed idna 3.15 is installed
- Ran the documented measure_tile_performance.py example successfully

Related to the ticket: https://citz-gdx.atlassian.net/browse/GDXDSD-8490